### PR TITLE
Reduce copies when reading repeated values

### DIFF
--- a/examples/ipc/my_struct.h
+++ b/examples/ipc/my_struct.h
@@ -18,7 +18,8 @@ typedef struct
   } data[50];
 } my_struct;
 
-#define my_struct_print(print, s, ...) print("%d\t%d\t%d" __VA_ARGS__ , s.data[0].ii, s.data[0].iii, s.data[0].iiii)
+#define my_struct_print(print, s, ...) print("%d\t%d\t%d" __VA_ARGS__ ,
+s.data[0].ii, s.data[0].iii, s.data[0].iiii)
 
 #define my_struct_inc(entry)    \
     do{                         \
@@ -31,16 +32,15 @@ typedef struct
     }while(0)
 */
 
-typedef struct
-{
+typedef struct {
   unsigned char i;
   float j;
 } my_struct;
 
-#define my_struct_print(print, s, ...) print("%u %f" __VA_ARGS__ , s.i, s.j)
+#define my_struct_print(print, s, ...) print("%u %f" __VA_ARGS__, s.i, s.j)
 
-#define my_struct_inc(entry)    \
-    do{                         \
-      ++(entry.i);   \
-      ++(entry.j);   \
-    }while(0)
+#define my_struct_inc(entry)                                                   \
+  do {                                                                         \
+    ++(entry.i);                                                               \
+    ++(entry.j);                                                               \
+  } while (0)

--- a/examples/ipc/reader.cpp
+++ b/examples/ipc/reader.cpp
@@ -9,27 +9,18 @@
 
 int run = 1;
 
-void sig_handler(int sig)
-{
-  run = 0;
-}
+void sig_handler(int sig) { run = 0; }
 
-
-int main()
-{
+int main() {
   signal(SIGINT, sig_handler);
 
-
-  while (run)
-  {
+  while (run) {
     my_struct entry;
 
-    if (ipc_read(entry, "/my/topic") == 0)
-    {
+    if (ipc_read(entry, "/my/topic") == 0) {
       debug("new entry:\t");
       my_struct_print(debug_plain, entry, "\n");
-    }
-    else
+    } else
       debug_error("no entry\n");
 
     usleep(3 * 1000);

--- a/examples/ipc/writer.cpp
+++ b/examples/ipc/writer.cpp
@@ -9,20 +9,14 @@
 
 int run = 1;
 
-void sig_handler(int sig)
-{
-  run = 0;
-}
+void sig_handler(int sig) { run = 0; }
 
-
-int main()
-{
+int main() {
   signal(SIGINT, sig_handler);
 
   my_struct entry = {};
 
-  while (run)
-  {
+  while (run) {
     ipc_write(entry, "/my/topic");
 
     my_struct_inc(entry);

--- a/examples/log/C.c
+++ b/examples/log/C.c
@@ -1,27 +1,23 @@
 #define LOG_PRINTF
-//#define LOG_FMT
+// #define LOG_FMT
 #include <tyndall/log/log.h>
 
-#include <unistd.h>
 #include <signal.h>
+#include <unistd.h>
 
 sig_atomic_t run = 1;
 
-void cb_sig(int sig)
-{
+void cb_sig(int sig) {
   log_info("got signal %d\n", sig);
   run = 0;
 }
 
-int main()
-{
+int main() {
   log_debug("hei %d\n", 3);
 
   signal(SIGINT, cb_sig);
 
-
-  while(run)
-  {
+  while (run) {
     log_debug("loopityloop\n");
 
     log_once_error("loopityloop\n");

--- a/examples/meta.cpp
+++ b/examples/meta.cpp
@@ -1,18 +1,15 @@
+#include <cstdio>
 #include <tyndall/meta/iterate.h>
 #include <tyndall/meta/strval.h>
 #include <tyndall/meta/typevals.h>
-#include <cstdio>
 #include <typeinfo>
 
-template<typename T>
-struct tstruct
-{
+template <typename T> struct tstruct {
   using Type = T;
   T a;
 };
 
-int main()
-{
+int main() {
   constexpr auto sv = "hei"_strval;
   printf("strval: %s\n", sv.c_str());
   printf("strval from type: %s\n", decltype(sv)::c_str());
@@ -20,20 +17,22 @@ int main()
   printf("strval sum: %s\n", ("hei"_strval + "du"_strval).c_str());
   printf("occurrences: %d\n", ("hei din sei"_strval).occurrences('i'));
   printf("replace: %s\n", ("hei din sei"_strval).replace<'i', 'y'>().c_str());
-  printf("remove_leading: %s\n", ("///hei din sei"_strval).remove_leading<'/'>().c_str());
+  printf("remove_leading: %s\n",
+         ("///hei din sei"_strval).remove_leading<'/'>().c_str());
   printf("to_strval: %s\n", to_strval<42>::c_str());
 
   {
     printf("typevals:\n");
     {
-      struct A{int a; float b;};
-      struct B{int a; float b;};
-      static constexpr auto col =
-      typevals{}
-      + 5
-      + A{4,2}
-      + B{3,9}
-      ;
+      struct A {
+        int a;
+        float b;
+      };
+      struct B {
+        int a;
+        float b;
+      };
+      static constexpr auto col = typevals{} + 5 + A{4, 2} + B{3, 9};
       printf("col size: %d\n", col.size());
 
       constexpr auto res = col.get<2>();
@@ -43,10 +42,7 @@ int main()
     }
 
     {
-      static constexpr auto c =
-      typevals{}
-      + tstruct<int>{5}
-      ;
+      static constexpr auto c = typevals{} + tstruct<int>{5};
       constexpr auto res = c.get<0>();
       printf("c res: %s\n", typeid(res).name());
       decltype(res)::Type t;
@@ -54,15 +50,10 @@ int main()
     }
 
     {
-      static constexpr auto c =
-      typevals{}
-      + tstruct<int>{-5}
-      + tstruct<float>{3}
-      + tstruct<unsigned>{8}
-      ;
+      static constexpr auto c = typevals{} + tstruct<int>{-5} +
+                                tstruct<float>{3} + tstruct<unsigned>{8};
 
-      iterate<c.size()>
-      ([](auto index){
+      iterate<c.size()>([](auto index) {
         printf("iteration %d: %s\n", index(), typeid(index).name());
       });
     }

--- a/examples/proto/binlog_read.cpp
+++ b/examples/proto/binlog_read.cpp
@@ -1,24 +1,20 @@
-#include <tyndall/proto/binlog.h>
+#include <cstdio>
 #include <google/protobuf/wrappers.pb.h>
 #include <thread>
-#include <cstdio>
+#include <tyndall/proto/binlog.h>
 
-int main()
-{
+int main() {
   int binlog_fd = binlog_open("log.bin");
-  if (binlog_fd == -1)
-  {
+  if (binlog_fd == -1) {
     printf("errno: %s\n", strerror(errno));
     exit(1);
   }
 
-  while(1)
-  {
+  while (1) {
     google::protobuf::Int32Value msg;
 
     int rc = binlog_read(binlog_fd, msg);
-    if (rc != 0)
-    {
+    if (rc != 0) {
       printf("errno: %s\n", strerror(errno));
       exit(1);
     }

--- a/examples/proto/binlog_write.cpp
+++ b/examples/proto/binlog_write.cpp
@@ -1,35 +1,28 @@
-#include <tyndall/proto/binlog.h>
+#include <csignal>
+#include <cstdio>
 #include <google/protobuf/wrappers.pb.h>
 #include <thread>
-#include <cstdio>
-#include <csignal>
+#include <tyndall/proto/binlog.h>
 
 sig_atomic_t run = 1;
 
-void signal_handler(int sig)
-{
-  run = 0;
-}
+void signal_handler(int sig) { run = 0; }
 
-int main()
-{
+int main() {
   int binlog_fd = binlog_create("log.bin");
-  if (binlog_fd == -1)
-  {
+  if (binlog_fd == -1) {
     printf("errno: %s\n", strerror(errno));
     exit(1);
   }
 
-  for(int i=0; run; ++i)
-  {
+  for (int i = 0; run; ++i) {
     google::protobuf::Int32Value msg;
     msg.set_value(i);
 
     printf("logging value: %d\n", msg.value());
 
     int rc = binlog_write(binlog_fd, msg);
-    if (rc != 0)
-    {
+    if (rc != 0) {
       printf("errno: %s\n", strerror(errno));
       exit(1);
     }

--- a/examples/proto/zmq_proto_pub.cpp
+++ b/examples/proto/zmq_proto_pub.cpp
@@ -1,26 +1,21 @@
-#include <tyndall/proto/zmq_proto.h>
-#include <google/protobuf/wrappers.pb.h>
-#include <csignal>
-#include <thread>
 #include <chrono>
+#include <csignal>
 #include <cstdio>
+#include <google/protobuf/wrappers.pb.h>
+#include <thread>
+#include <tyndall/proto/zmq_proto.h>
 
 sig_atomic_t run = 1;
 
-void signal_handler(int sig)
-{
-  run = 0;
-}
+void signal_handler(int sig) { run = 0; }
 
-int main()
-{
+int main() {
   zmq_proto::context_t context{1};
   zmq_proto::socket_t<zmq_proto::PUB> socket(context, "tcp://*:5444");
 
   signal(SIGINT, signal_handler);
 
-  for(int i=0; run; ++i)
-  {
+  for (int i = 0; run; ++i) {
     google::protobuf::Int32Value msg;
     msg.set_value(i);
 
@@ -32,7 +27,6 @@ int main()
 
     std::this_thread::sleep_for(std::chrono::milliseconds{3});
   }
-
 
   return 0;
 }

--- a/examples/proto/zmq_proto_sub.cpp
+++ b/examples/proto/zmq_proto_sub.cpp
@@ -1,31 +1,25 @@
-#include <tyndall/proto/zmq_proto.h>
-#include <google/protobuf/wrappers.pb.h>
-#include <csignal>
-#include <thread>
 #include <chrono>
+#include <csignal>
 #include <cstdio>
+#include <google/protobuf/wrappers.pb.h>
+#include <thread>
+#include <tyndall/proto/zmq_proto.h>
 
 sig_atomic_t run = 1;
 
-void signal_handler(int sig)
-{
-  run = 0;
-}
+void signal_handler(int sig) { run = 0; }
 
-int main()
-{
+int main() {
   zmq_proto::context_t context{1};
   zmq_proto::socket_t<zmq_proto::SUB> socket(context, "tcp://127.0.0.1:5444");
 
   signal(SIGINT, signal_handler);
 
-  while(run)
-  {
+  while (run) {
     google::protobuf::Int32Value msg;
 
     int rc = zmq_proto::recv(msg, socket);
-    if (rc != 0)
-    {
+    if (rc != 0) {
       printf("errno: %s\n", strerror(errno));
       exit(1);
     }
@@ -34,7 +28,6 @@ int main()
 
     std::this_thread::sleep_for(std::chrono::milliseconds{3});
   }
-
 
   return 0;
 }

--- a/tests/ipc/ipc.cpp
+++ b/tests/ipc/ipc.cpp
@@ -2,34 +2,36 @@
 #include <tyndall/ipc/ipc.h>
 #include <tyndall/meta/macro.h>
 
-struct my_struct
-{
+struct my_struct {
   long a;
   double b;
   char c;
   unsigned long d;
-  //bool operator==(my_struct) = default; // c++20
-  bool operator==(my_struct rhs)
-  {
-    return (rhs.a == a)
-      && (rhs.b == b)
-      && (rhs.c == c)
-      && (rhs.d == d);
+  // bool operator==(my_struct) = default; // c++20
+  bool operator==(my_struct rhs) {
+    return (rhs.a == a) && (rhs.b == b) && (rhs.c == c) && (rhs.d == d);
   }
 };
 
-const my_struct ref
-{
-  .a = 3,
-  .b = 1,
-  .c = 4,
-  .d = 2,
+const my_struct ref{
+    .a = 3,
+    .b = 1,
+    .c = 4,
+    .d = 2,
 };
 
-#define check(cond) do { if (!(cond)){ ipc_cleanup(); printf( __FILE__ ":" M_STRINGIFY(__LINE__) " " "Assertion failed: " #cond "\n"); exit(1); }} while(0)
+#define check(cond)                                                            \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      ipc_cleanup();                                                           \
+      printf(__FILE__ ":" M_STRINGIFY(__LINE__) " "                            \
+                                                "Assertion failed: " #cond     \
+                                                "\n");                         \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
 
-int main()
-{
+int main() {
   ipc_cleanup();
   {
     {
@@ -63,13 +65,13 @@ int main()
 
   {
     {
-      //ipc_writer<my_struct, strval_t("test/mt_safe")> writer;
+      // ipc_writer<my_struct, strval_t("test/mt_safe")> writer;
       auto writer = create_ipc_writer(my_struct, "test/mt_safe");
       writer.write(ref);
     }
 
     {
-      //ipc_reader<my_struct, strval_t("test/mt_safe")> reader;
+      // ipc_reader<my_struct, strval_t("test/mt_safe")> reader;
       auto reader = create_ipc_reader(my_struct, "test/mt_safe");
       my_struct entry;
       int rc = reader.read(entry);
@@ -122,7 +124,8 @@ int main()
 
   // moving
   {
-    ipc_rtid_reader<my_struct> a = create_ipc_rtid_reader<my_struct>("test/moving");
+    ipc_rtid_reader<my_struct> a =
+        create_ipc_rtid_reader<my_struct>("test/moving");
 
     ipc_rtid_reader<my_struct> b;
     b = std::move(a);

--- a/tests/meta/macro.cpp
+++ b/tests/meta/macro.cpp
@@ -1,9 +1,7 @@
 #include <tyndall/meta/macro.h>
 
-
-int main()
-{
-  #define RANGE_TEST(i, _) static_assert((0 <= i) && (i < 8));
+int main() {
+#define RANGE_TEST(i, _) static_assert((0 <= i) && (i < 8));
 
   M_EVAL(M_RANGE(RANGE_TEST, 0, 8))
 }

--- a/tests/meta/strval.cpp
+++ b/tests/meta/strval.cpp
@@ -1,12 +1,10 @@
-#include <tyndall/meta/strval.h>
-#include <type_traits>
-#include <cstring>
 #include <cassert>
+#include <cstring>
+#include <tyndall/meta/strval.h>
 #include <tyndall/meta/typeinfo.h>
+#include <type_traits>
 
-
-int main()
-{
+int main() {
   constexpr auto hei = "hei"_strval;
   decltype(hei)::c_str();
   static_assert(hei.get<0>() == 'h');
@@ -24,10 +22,9 @@ int main()
   {
     char buf[100];
     memset(buf, 0, sizeof(buf));
-    void* buf_p = buf;
-    auto hei_p = static_cast<std::remove_cvref_t<decltype(hei)>*>(buf_p);
+    void *buf_p = buf;
+    auto hei_p = static_cast<std::remove_cvref_t<decltype(hei)> *>(buf_p);
     *hei_p = {};
     assert(strcmp(buf, hei.c_str()) == 0);
   }
-
 }

--- a/tests/meta/typevals.cpp
+++ b/tests/meta/typevals.cpp
@@ -1,47 +1,42 @@
-#include <tyndall/meta/typevals.h>
 #include <tyndall/meta/iterate.h>
+#include <tyndall/meta/typevals.h>
 
-
-int main()
-{
+int main() {
   {
-    constexpr struct A
-    {
-      int a; float b;
-      bool operator==(const A&) const = default;
-    } a{4,2};
+    constexpr struct A {
+      int a;
+      float b;
+      bool operator==(const A &) const = default;
+    } a{4, 2};
 
-    constexpr struct B
-    {
+    constexpr struct B {
       char a;
       double b;
       long c;
-      bool operator==(const B&) const = default;
-    } b{6,6,6};
+      bool operator==(const B &) const = default;
+    } b{6, 6, 6};
 
-    static constexpr auto tv =
-      typevals{}
-      + 5
-      + b
-      + a
-      + B{0,0,7};
+    static constexpr auto tv = typevals{} + 5 + b + a + B{0, 0, 7};
 
     static_assert(tv.size() == 4);
     static_assert(tv.get<0>() == 5);
     static_assert(tv.get<1>() == b);
     static_assert(tv.get<2>() == a);
-    static_assert(tv.get<3>() == B{0,0,7});
+    static_assert(tv.get<3>() == B{0, 0, 7});
 
     static_assert(tv[std::integral_constant<int, 2>()] == a);
 
-    iterate<tv.size()>
-    ([a, b](auto index){
+    iterate<tv.size()>([a, b](auto index) {
       static_assert((index >= 0) && (index < tv.size()));
 
-      if constexpr (index == 0) static_assert(tv[index] == 5);
-      else if constexpr (index == 1) static_assert(tv[index] == b);
-      else if constexpr (index == 2) static_assert(tv[index] == a);
-      else if constexpr (index == 3) static_assert(tv[index] == B{0,0,7});
+      if constexpr (index == 0)
+        static_assert(tv[index] == 5);
+      else if constexpr (index == 1)
+        static_assert(tv[index] == b);
+      else if constexpr (index == 2)
+        static_assert(tv[index] == a);
+      else if constexpr (index == 3)
+        static_assert(tv[index] == B{0, 0, 7});
     });
   }
 }

--- a/tests/proto/zmq_proto.cpp
+++ b/tests/proto/zmq_proto.cpp
@@ -1,19 +1,25 @@
-#include <tyndall/proto/zmq_proto.h>
-#include <google/protobuf/wrappers.pb.h>
-#include <tyndall/meta/macro.h>
-#include <thread>
 #include <assert.h>
+#include <google/protobuf/wrappers.pb.h>
+#include <thread>
+#include <tyndall/meta/macro.h>
+#include <tyndall/proto/zmq_proto.h>
 
-#define check(cond) do { if (!(cond)){ printf( __FILE__ ":" M_STRINGIFY(__LINE__) " " "Assertion failed: " #cond "\n"); exit(1); }} while(0)
+#define check(cond)                                                            \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      printf(__FILE__ ":" M_STRINGIFY(__LINE__) " "                            \
+                                                "Assertion failed: " #cond     \
+                                                "\n");                         \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
 
-int main()
-{
+int main() {
   zmq_proto::context_t context{1};
   zmq_proto::socket_t<zmq_proto::PUB> pub(context, "tcp://*:5444");
   zmq_proto::socket_t<zmq_proto::SUB> sub(context, "tcp://127.0.0.1:5444");
 
-  std::thread sub_thread([&sub]()
-  {
+  std::thread sub_thread([&sub]() {
     google::protobuf::Int32Value msg;
     msg.set_value(0);
 
@@ -24,8 +30,7 @@ int main()
 
   std::this_thread::sleep_for(std::chrono::milliseconds{50});
 
-  std::thread pub_thread([&pub]()
-  {
+  std::thread pub_thread([&pub]() {
     google::protobuf::Int32Value msg;
     msg.set_value(42);
 

--- a/tests/reflect/n_fields.cpp
+++ b/tests/reflect/n_fields.cpp
@@ -1,13 +1,11 @@
-#include <tyndall/reflect/n_fields.h>
 #include <array>
+#include <tyndall/reflect/n_fields.h>
 
 #include <string>
 
-int main()
-{
+int main() {
   {
-    struct S
-    {
+    struct S {
       float floating_point = 3.14f;
       int integer = 42;
       unsigned char unsigned_char = 255;
@@ -19,5 +17,4 @@ int main()
 
     static_assert(n_fields<decltype(s)>() == 5);
   }
-
 }

--- a/tests/reflect/reflect.cpp
+++ b/tests/reflect/reflect.cpp
@@ -1,24 +1,21 @@
-#include <tyndall/reflect/reflect.h>
-#include <string>
-#include <typeinfo>
 #include <array>
+#include <string>
+#include <tyndall/reflect/reflect.h>
+#include <typeinfo>
 
-int main()
-{
+int main() {
 
   {
-    struct S
-    {
+    struct S {
       float floating_point;
       int integer;
       unsigned char unsigned_char = 5;
     };
 
-    constexpr S s
-    {
-      .floating_point = 3.14f,
-      .integer = 42,
-      .unsigned_char = 255,
+    constexpr S s{
+        .floating_point = 3.14f,
+        .integer = 42,
+        .unsigned_char = 255,
     };
 
     constexpr auto floating_point = reflect(s).get<0>();
@@ -35,10 +32,12 @@ int main()
   }
 
   {
-    struct A{int a; int b;};
+    struct A {
+      int a;
+      int b;
+    };
 
-    struct S
-    {
+    struct S {
       float floating_point;
       int integer;
       int another_integer;
@@ -54,7 +53,8 @@ int main()
     static_assert(size == 8);
 
     constexpr auto b = reflect(s).get<7>();
-    static_assert(std::is_same_v<std::remove_cv_t<decltype(b)>, std::remove_cv_t<decltype(s.b)>>);
+    static_assert(std::is_same_v<std::remove_cv_t<decltype(b)>,
+                                 std::remove_cv_t<decltype(s.b)>>);
 
     static_assert(reflect(s).get_format() == "fiijhtiijjj"_strval);
   }
@@ -69,8 +69,14 @@ int main()
   }
 
   {
-    struct S{ int a; unsigned char b; float c, d; S(){}} msg;
-    static_assert(!std::is_aggregate_v<decltype(msg)> && !std::is_scalar_v<decltype(msg)>);
+    struct S {
+      int a;
+      unsigned char b;
+      float c, d;
+      S() {}
+    } msg;
+    static_assert(!std::is_aggregate_v<decltype(msg)> &&
+                  !std::is_scalar_v<decltype(msg)>);
     static_assert(reflect<decltype(msg)>().get_format() == ""_strval);
     static_assert(sizeof(reflect<decltype(msg)>().get_format()) == 0);
     static_assert(reflect<decltype(msg)>().size() == 0);

--- a/tests/ros_context/ros_context.cpp
+++ b/tests/ros_context/ros_context.cpp
@@ -41,6 +41,12 @@ int main() {
 
   {
     {
+      i32 tmp;
+      int rc = ros_context_read(tmp, "/test/standard");
+      check((rc == -1) && (errno == ENOMSG));
+    }
+
+    {
       i32 entry = ref;
       ros_context_write(entry, "/test/standard");
     }

--- a/tools/ipc_cleanup.cpp
+++ b/tools/ipc_cleanup.cpp
@@ -1,11 +1,10 @@
-#include <stdio.h>
 #include <dirent.h>
+#include <stdio.h>
 #include <tyndall/ipc/ipc.h>
 #include <tyndall/ipc/shmem.h>
 
-int main()
-{
-  const char* prefix = IPC_SHMEM_PREFIX;
+int main() {
+  const char *prefix = IPC_SHMEM_PREFIX;
 
   DIR *dir;
   struct dirent *ent;
@@ -13,17 +12,15 @@ int main()
   if (dir == NULL)
     return -1;
 
-  while((ent = readdir(dir)) != NULL)
-  {
+  while ((ent = readdir(dir)) != NULL) {
     const char *dir_name = ent->d_name;
     int match = 1;
 
-    for (int i=0; i < (int)strlen(prefix); ++i)
+    for (int i = 0; i < (int)strlen(prefix); ++i)
       if (dir_name[i] != prefix[i])
         match = 0;
 
-    if (match)
-    {
+    if (match) {
       printf("removing %s\n", dir_name);
       shmem_unlink(dir_name);
     }

--- a/tools/ipc_read.cpp
+++ b/tools/ipc_read.cpp
@@ -1,58 +1,50 @@
-#include <stdio.h>
-#include <stdint.h>
-#include <stdlib.h>
 #include <assert.h>
-//#include <tyndall/ext/embed.hpp>
-//#include <experimental/reflect>
-#include <typeinfo>
-#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+// #include <tyndall/ext/embed.hpp>
+// #include <experimental/reflect>
 #include <ctype.h>
+#include <string.h>
+#include <typeinfo>
 
 // ipc
-#include <sys/stat.h>
-#include <sys/mman.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <tyndall/ipc/seq_lock.h>
 #include <tyndall/reflect/print_format.h>
+#include <unistd.h>
 
-void print(char* fmt, const char* buf, size_t buf_size)
-{
-  const char* b = buf;
-  for (char* f = fmt; (*f!='\0'); ++f)
-  {
-    if (isdigit(*f))
-    {
+void print(char *fmt, const char *buf, size_t buf_size) {
+  const char *b = buf;
+  for (char *f = fmt; (*f != '\0'); ++f) {
+    if (isdigit(*f)) {
       long num = strtol(f, &f, 10);
       printf("<%ld>, ", num);
       b += num;
     }
 
     size_t printed = print_format(*f, b);
-    if (printed == 0)
-    {
-      switch(*f)
-      {
-        case 's':
-          printf("%ss, ", b);
-          printed = strlen(b);
-          b += printed;
-          break;
-        default:
-          printf("error, wrong parameter: %c\n", *f);
+    if (printed == 0) {
+      switch (*f) {
+      case 's':
+        printf("%ss, ", b);
+        printed = strlen(b);
+        b += printed;
+        break;
+      default:
+        printf("error, wrong parameter: %c\n", *f);
       }
       if (printed == 0)
         break;
-    }
-    else
-    {
+    } else {
       printf(",\t");
       b += printed;
     }
 
-    if ((size_t)(b - buf) > buf_size)
-    {
+    if ((size_t)(b - buf) > buf_size) {
       printf("fmt is too large for buffer at %zu", buf_size);
       break;
     }
@@ -60,21 +52,19 @@ void print(char* fmt, const char* buf, size_t buf_size)
   printf("\n");
 }
 
-int main(int argc, char** argv)
-{
-  if (argc < 2)
-  {
+int main(int argc, char **argv) {
+  if (argc < 2) {
     printf("Usage: %s <ipc_name> <format>\n", argv[0]);
     exit(1);
   }
 
-  const char* ipc_id = argv[1];
+  const char *ipc_id = argv[1];
   const char *ipc_prefix = "/dev/shm/";
 
   if (strncmp(ipc_id, ipc_prefix, strlen(ipc_prefix)) == 0)
     ipc_id += strlen(ipc_prefix);
 
-  //printf("id: %s\n", ipc_id);
+  // printf("id: %s\n", ipc_id);
 
   // ipc
   int fd = shm_open(ipc_id, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
@@ -88,15 +78,16 @@ int main(int argc, char** argv)
     ipc_size = st.st_size;
   }
 
-  void* const mapped = mmap(NULL, ipc_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  void *const mapped =
+      mmap(NULL, ipc_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   assert(mapped != MAP_FAILED);
   assert(reinterpret_cast<uintptr_t>(mapped) % CACHELINE_BYTES == 0);
 
-  unsigned* ipc_seq = (unsigned*)mapped;
-  const char* const ipc_buf = (const char*)mapped + CACHELINE_BYTES;
-  const size_t buf_size = ipc_size - 2*sizeof(int) - CACHELINE_BYTES;
-  char* buf = (char*)malloc(buf_size + CACHELINE_BYTES);
-  char* const buf_to_free = buf;
+  unsigned *ipc_seq = (unsigned *)mapped;
+  const char *const ipc_buf = (const char *)mapped + CACHELINE_BYTES;
+  const size_t buf_size = ipc_size - 2 * sizeof(int) - CACHELINE_BYTES;
+  char *buf = (char *)malloc(buf_size + CACHELINE_BYTES);
+  char *const buf_to_free = buf;
 
   // align buf
   {
@@ -107,57 +98,48 @@ int main(int argc, char** argv)
   }
 
   unsigned seq = 0;
-  while(1)
-  {
+  while (1) {
     bool new_buf = false;
     {
 
       unsigned seq1;
-      do
-      {
+      do {
         seq1 = seq_lock_read_begin(ipc_seq);
         memcpy(buf, ipc_buf, buf_size);
 
       } while (seq_lock_read_retry(ipc_seq, seq1));
 
-      if (seq1 != seq)
-      {
+      if (seq1 != seq) {
         new_buf = true;
         seq = seq1;
       }
     }
 
-    if (new_buf)
-    {
-      if (argc > 2)
-      {
-        char* fmt = argv[2];
+    if (new_buf) {
+      if (argc > 2) {
+        char *fmt = argv[2];
         print(fmt, buf, buf_size);
-      }
-      else
-      {
+      } else {
         // extract debug format
         constexpr int type_info_hash_size = 4;
         const size_t debug_tail_size = ipc_size % CACHELINE_BYTES;
 
-        if (debug_tail_size > type_info_hash_size)
-        {
-          const size_t debug_format_size = debug_tail_size - type_info_hash_size;
-          char* const debug_format_loc = static_cast<char*>(mapped) + ipc_size - debug_format_size;
+        if (debug_tail_size > type_info_hash_size) {
+          const size_t debug_format_size =
+              debug_tail_size - type_info_hash_size;
+          char *const debug_format_loc =
+              static_cast<char *>(mapped) + ipc_size - debug_format_size;
 
-          char* fmt = debug_format_loc;
+          char *fmt = debug_format_loc;
           print(fmt, buf, buf_size);
-        }
-        else
-        {
-          for (size_t i=0; i<buf_size; ++i)
+        } else {
+          for (size_t i = 0; i < buf_size; ++i)
             printf("%02x", buf[i]);
           printf("\n");
-          //printf("int: %d\n", *(int*)buf);
+          // printf("int: %d\n", *(int*)buf);
         }
       }
-    }
-    else
+    } else
       usleep(1000);
   }
 

--- a/tyndall/debug.h
+++ b/tyndall/debug.h
@@ -1,15 +1,21 @@
-#include <stdio.h>
 #include <errno.h>
-#include <string.h>
+#include <stdio.h>
 #include <stdlib.h> // for exit
+#include <string.h>
 
 #ifdef DEBUG
 #define _debug_stringify(x) #x
 #define debug_stringify(x) _debug_stringify(x)
 
-#define debug_f(fd, ...) fprintf(fd, "[" __FILE__ " line\t" debug_stringify(__LINE__) "] " __VA_ARGS__)
+#define debug_f(fd, ...)                                                       \
+  fprintf(fd, "[" __FILE__ " line\t" debug_stringify(__LINE__) "]"             \
+                                                               " " __VA_ARGS__)
 
-#define debug_flush(fd, ...) do { debug_f(fd, __VA_ARGS__); fflush(fd); } while(0)
+#define debug_flush(fd, ...)                                                   \
+  do {                                                                         \
+    debug_f(fd, __VA_ARGS__);                                                  \
+    fflush(fd);                                                                \
+  } while (0)
 
 #ifndef debug_stdout
 #define debug_stdout stdout
@@ -23,26 +29,45 @@
 #define debug_plain(...) fprintf(debug_stdout, __VA_ARGS__)
 #define debug_instant(...) debug_flush(debug_stdout, __VA_ARGS__)
 
-
 #define debug_color_red "\033[31m"
-#define debug_color_reset   "\033[0m"
-#define debug_color_bold    "\033[1m"
-#define debug_error(fmt, ...) debug_f(debug_stderr, debug_color_red debug_color_bold "[errno: %s] " fmt debug_color_reset, strerror(errno) __VA_OPT__(,) __VA_ARGS__)
+#define debug_color_reset "\033[0m"
+#define debug_color_bold "\033[1m"
+#define debug_error(fmt, ...)                                                  \
+  debug_f(debug_stderr,                                                        \
+          debug_color_red debug_color_bold                                     \
+          "[errno: %s] " fmt debug_color_reset,                                \
+          strerror(errno) __VA_OPT__(, ) __VA_ARGS__)
 #define debug_error_plain(...) fprintf(debug_stderr, __VA_ARGS__);
 
+#define debug_assert(cond, ...)                                                \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      debug_error("assertion failed: (" debug_stringify(cond) ") errno: %s\n", \
+                  strerror(errno));                                            \
+      __VA_ARGS__ __VA_OPT__(; break;) exit(1);                                \
+    }                                                                          \
+  } while (0)
 
+#define debug_assert_v(cond, ...)                                              \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      debug_error(__VA_ARGS__);                                                \
+      debug_error_plain("%s\n", strerror(errno)); /*exit(-1);*/                \
+    }                                                                          \
+  } while (0)
 
-#define debug_assert(cond, ...) do { if (!(cond)) { debug_error("assertion failed: (" debug_stringify(cond) ") errno: %s\n", strerror(errno)); __VA_ARGS__ __VA_OPT__(;break;) exit(1); } } while(0)
-
-#define debug_assert_v(cond, ...) do { if (!(cond)) { debug_error(__VA_ARGS__); debug_error_plain("%s\n", strerror(errno)); /*exit(-1);*/ } } while(0)
-
-#define debug_abort(...) do { debug_assert_v(false, __VA_ARGS__); exit(1); } while(0)
-
-
+#define debug_abort(...)                                                       \
+  do {                                                                         \
+    debug_assert_v(false, __VA_ARGS__);                                        \
+    exit(1);                                                                   \
+  } while (0)
 
 #else
 
-#define debug_nothing(...) do { (void)sizeof(printf(__VA_ARGS__)); } while(0)
+#define debug_nothing(...)                                                     \
+  do {                                                                         \
+    (void)sizeof(printf(__VA_ARGS__));                                         \
+  } while (0)
 
 #define debug(...) debug_nothing(__VA_ARGS__)
 #define debug_plain(...) debug_nothing(__VA_ARGS__)
@@ -51,6 +76,12 @@
 #define debug_error(...) debug_nothing(__VA_ARGS__)
 #define debug_error_plain(...) debug_nothing(__VA_ARGS__)
 
-#define debug_assert(cond, ...) do { (void)sizeof(({ __VA_ARGS__ ; cond; })); } while(0)
+#define debug_assert(cond, ...)                                                \
+  do {                                                                         \
+    (void)sizeof(({                                                            \
+      __VA_ARGS__;                                                             \
+      cond;                                                                    \
+    }));                                                                       \
+  } while (0)
 
 #endif

--- a/tyndall/ipc/id.h
+++ b/tyndall/ipc/id.h
@@ -1,55 +1,62 @@
 #pragma once
 #include <string>
-#include <tyndall/meta/strval.h>
 #include <tyndall/meta/hash.h>
+#include <tyndall/meta/strval.h>
 
 #ifndef IPC_SHMEM_PREFIX
-//                              echo ipc | sha1sum  # more unique shared memory names reduce the chance of name collisions
-#define IPC_SHMEM_PREFIX "ipc" "1ef42bc4e0bbfeb0ac34bc3642732768cf6f77b7"
+//                              echo ipc | sha1sum  # more unique shared memory
+//                              names reduce the chance of name collisions
+#define IPC_SHMEM_PREFIX                                                       \
+  "ipc"                                                                        \
+  "1ef42bc4e0bbfeb0ac34bc3642732768cf6f77b7"
 #endif
 
-// Shared memory files all go in /dev/shm, so they need to be unique, and they can't have folders.
-// We take names that look like absolute paths, like "/my-process/my_topic".
-// We start with a prepend a constant unique prefix (IPC_SHMEM_PREFIX),
-// Then we add the id, without leading slashes, and with the remaining slashes replaced with underscores.
-// And lastly, we append a hash of the the id without leading slashes, but with slashes.
-// The last hash is to distinguish between eg. my/topic and my_topic.
+// Shared memory files all go in /dev/shm, so they need to be unique, and they
+// can't have folders. We take names that look like absolute paths, like
+// "/my-process/my_topic". We start with a prepend a constant unique prefix
+// (IPC_SHMEM_PREFIX), Then we add the id, without leading slashes, and with the
+// remaining slashes replaced with underscores. And lastly, we append a hash of
+// the the id without leading slashes, but with slashes. The last hash is to
+// distinguish between eg. my/topic and my_topic.
 
 // Note that "my-topic" gets the same id as "/my-topic" and "//my-topic" etc.
 
 // Compile time id generation:
 // Meant to take strval as template parameter.
-template<typename STRING>
-using id_remove_leading_slashes = decltype(STRING::template remove_leading<'/'>());
+template <typename STRING>
+using id_remove_leading_slashes =
+    decltype(STRING::template remove_leading<'/'>());
 
-template<typename STRING>
+template <typename STRING>
 using id_hash = decltype(to_strval<hash_fnv1a_32<STRING>()>{});
 
-template<typename STRING>
-using id_replace_slashes_with_underscores = decltype(STRING::template replace<'/', '_'>());
+template <typename STRING>
+using id_replace_slashes_with_underscores =
+    decltype(STRING::template replace<'/', '_'>());
 
-template<typename ID>
+template <typename ID>
 using id_prepare =
-  decltype(create_strval(IPC_SHMEM_PREFIX)
-  + "_"_strval
-  + id_replace_slashes_with_underscores<id_remove_leading_slashes<ID>>{} // switch slashes with underscores
-  + "_"_strval
-  + id_hash<id_remove_leading_slashes<ID>>{} // hash id to prevent name clash between f.ex. /my/topic and my_topic
-  );
-
+    decltype(create_strval(IPC_SHMEM_PREFIX) + "_"_strval +
+             id_replace_slashes_with_underscores<
+                 id_remove_leading_slashes<ID>>{}
+             // switch slashes with underscores
+             + "_"_strval + id_hash<id_remove_leading_slashes<ID>>{}
+             // hash id to prevent name clash between f.ex. /my/topic and
+             // my_topic
+    );
 
 // runtime id generation
-template<typename STORAGE>
-static inline std::string id_rtid_prepare(const char* id)
-{
+template <typename STORAGE>
+static inline std::string id_rtid_prepare(const char *id) {
   // remove leading slashes
   while (*id == '/')
     ++id;
 
-  std::string prepared_id = IPC_SHMEM_PREFIX "_" + std::string{id} + "_" + std::to_string(hash_fnv1a_32(id, strlen(id)));
+  std::string prepared_id = IPC_SHMEM_PREFIX "_" + std::string{id} + "_" +
+                            std::to_string(hash_fnv1a_32(id, strlen(id)));
 
   // replace slash with underscore
-  for (char& c : prepared_id)
+  for (char &c : prepared_id)
     if (c == '/')
       c = '_';
 

--- a/tyndall/ipc/ipc.h
+++ b/tyndall/ipc/ipc.h
@@ -3,40 +3,43 @@
 
 #ifdef __cplusplus
 
-#include <tyndall/meta/strval.h>
-#include "seq_lock.h"
 #include "id.h"
 #include "ipc_rtid.h"
+#include "seq_lock.h"
+#include <tyndall/meta/strval.h>
 
-// ipc_write and ipc_read are templated on storage type and id, so that the transport will be initiated only on calls with new combinations of storage type and id.
-// The id needs to be a string literal, otherwise use ipc_lazy_write / read (for strval), or ipc_rtid_write / read (for c strings).
-#define ipc_write(entry, id) ipc_lazy_write(entry, id ## _strval)
+// ipc_write and ipc_read are templated on storage type and id, so that the
+// transport will be initiated only on calls with new combinations of storage
+// type and id. The id needs to be a string literal, otherwise use
+// ipc_lazy_write / read (for strval), or ipc_rtid_write / read (for c strings).
+#define ipc_write(entry, id) ipc_lazy_write(entry, id##_strval)
 
 // ipc_read return value: 0 on success, -1 on failure.
 // On failure, ERRNO is ENOMSG or EAGAIN.
 // ENOMSG means there is no message available.
-// EAGAIN means there is no new message available, and the last message received will be returned instead.
-#define ipc_read(entry, id) ipc_lazy_read(entry, id ## _strval)
+// EAGAIN means there is no new message available, and the last message received
+// will be returned instead.
+#define ipc_read(entry, id) ipc_lazy_read(entry, id##_strval)
 
-template<typename STORAGE, typename ID>
+template <typename STORAGE, typename ID>
 using ipc_writer = shmem_buf<seq_lock<STORAGE>, SHMEM_WRITE, id_prepare<ID>>;
-template<typename STORAGE, typename ID>
+template <typename STORAGE, typename ID>
 using ipc_reader = shmem_buf<seq_lock<STORAGE>, SHMEM_READ, id_prepare<ID>>;
 
-#define create_ipc_writer(storage_type, id) (ipc_writer<storage_type, decltype(id ## _strval)>{})
-#define create_ipc_reader(storage_type, id) (ipc_reader<storage_type, decltype(id ## _strval)>{})
+#define create_ipc_writer(storage_type, id)                                    \
+  (ipc_writer<storage_type, decltype(id##_strval)>{})
+#define create_ipc_reader(storage_type, id)                                    \
+  (ipc_reader<storage_type, decltype(id##_strval)>{})
 
-template<typename STORAGE, typename ID>
-static inline void ipc_lazy_write(const STORAGE& entry, ID)
-{
+template <typename STORAGE, typename ID>
+static inline void ipc_lazy_write(const STORAGE &entry, ID) {
   static ipc_writer<STORAGE, ID> writer;
 
   writer.write(entry);
 }
 
-template<typename STORAGE, typename ID>
-static inline int ipc_lazy_read(STORAGE& entry, ID)
-{
+template <typename STORAGE, typename ID>
+static inline int ipc_lazy_read(STORAGE &entry, ID) {
   static ipc_reader<STORAGE, ID> reader;
 
   return reader.read(entry);
@@ -44,7 +47,4 @@ static inline int ipc_lazy_read(STORAGE& entry, ID)
 
 #endif
 
-static inline int ipc_cleanup()
-{
-  return shmem_unlink_all(IPC_SHMEM_PREFIX);
-}
+static inline int ipc_cleanup() { return shmem_unlink_all(IPC_SHMEM_PREFIX); }

--- a/tyndall/ipc/ipc_rtid.h
+++ b/tyndall/ipc/ipc_rtid.h
@@ -1,57 +1,62 @@
 #pragma once
 #include <vector>
 
-#include <tyndall/meta/typeinfo.h>
-#include "shmem.h"
-#include "seq_lock.h"
 #include "id.h"
+#include "seq_lock.h"
+#include "shmem.h"
+#include <tyndall/meta/typeinfo.h>
 
-// Implementation of ipc structs and methods from ipc.h, but with id specified at runtime.
-// The normal, non-runtime implementation is preferred since it is cleaner.
+// Implementation of ipc structs and methods from ipc.h, but with id specified
+// at runtime. The normal, non-runtime implementation is preferred since it is
+// cleaner.
 
-template<typename STORAGE>
+template <typename STORAGE>
 using ipc_rtid_writer = shmem_buf<seq_lock<STORAGE>, SHMEM_WRITE>;
-template<typename STORAGE>
+template <typename STORAGE>
 using ipc_rtid_reader = shmem_buf<seq_lock<STORAGE>, SHMEM_READ>;
 
 // Return and errno values are the same as for ipc_write / read
-#define ipc_rtid_write(entry, id) create_ipc_rtid_lazy<ipc_rtid_writer, std::remove_cvref_t<decltype(entry)>>(id).write(entry)
-#define ipc_rtid_read(entry, id) create_ipc_rtid_lazy<ipc_rtid_reader, std::remove_cvref_t<decltype(entry)>>(id).read(entry)
+#define ipc_rtid_write(entry, id)                                              \
+  create_ipc_rtid_lazy<ipc_rtid_writer, std::remove_cvref_t<decltype(entry)>>( \
+      id)                                                                      \
+      .write(entry)
+#define ipc_rtid_read(entry, id)                                               \
+  create_ipc_rtid_lazy<ipc_rtid_reader, std::remove_cvref_t<decltype(entry)>>( \
+      id)                                                                      \
+      .read(entry)
 
-template<typename STORAGE>
-static inline ipc_rtid_writer<STORAGE> create_ipc_rtid_writer(const char* id)
-{
+template <typename STORAGE>
+static inline ipc_rtid_writer<STORAGE> create_ipc_rtid_writer(const char *id) {
   std::string prepared_id = id_rtid_prepare<STORAGE>(id);
   return ipc_rtid_writer<STORAGE>{prepared_id.c_str()};
 }
 
-template<typename STORAGE>
-static inline ipc_rtid_reader<STORAGE> create_ipc_rtid_reader(const char* id)
-{
+template <typename STORAGE>
+static inline ipc_rtid_reader<STORAGE> create_ipc_rtid_reader(const char *id) {
   std::string prepared_id = id_rtid_prepare<STORAGE>(id);
   return ipc_rtid_reader<STORAGE>{prepared_id.c_str()};
 }
 
-// To keep track of lazily created ipc objects, the runtime id needs to be looked up in a registry.
-// You might want to keep track of it manually instead.
-template<template<typename>typename TRANSPORT, typename STORAGE>
-static inline TRANSPORT<STORAGE>& create_ipc_rtid_lazy(const char* id)
-{
+// To keep track of lazily created ipc objects, the runtime id needs to be
+// looked up in a registry. You might want to keep track of it manually instead.
+template <template <typename> typename TRANSPORT, typename STORAGE>
+static inline TRANSPORT<STORAGE> &create_ipc_rtid_lazy(const char *id) {
   std::string prepared_id = id_rtid_prepare<STORAGE>(id);
 
-  // manual registry is needed as substitution for compile time template matching
-  struct registry_item
-  {
+  // manual registry is needed as substitution for compile time template
+  // matching
+  struct registry_item {
     std::string id;
     TRANSPORT<STORAGE> transport;
   };
   static std::vector<registry_item> registry;
 
-  for (auto& item : registry)
+  for (auto &item : registry)
     if (item.id == prepared_id)
       return item.transport;
 
-  registry.push_back(registry_item{ .id = prepared_id, .transport = TRANSPORT<STORAGE>{prepared_id.c_str()} });
+  registry.push_back(registry_item{
+      .id = prepared_id, .transport = TRANSPORT<STORAGE>{prepared_id.c_str()}});
 
   return registry.back().transport;
 }

--- a/tyndall/ipc/seq_lock.h
+++ b/tyndall/ipc/seq_lock.h
@@ -96,18 +96,17 @@ public:
    * always gets the most recent entry. If a write is in progress, the reader
    * will retry until the write is complete.
    *
-   * Reading the same entry multiple times will return the same entry but will
-   * return -1 and set errno to EAGAIN if the entry has not been written to yet.
-   * Separate processes will each be allowed to read the entry once before
-   * getting EAGAIN.
+   * Reading the same entry multiple times will return the same entry the same
+   * entry unless always_update_entry is set to false. This returns -1 and sets
+   * errno to EAGAIN. Separate processes will each be allowed to read the entry
+   * once before getting EAGAIN.
    *
    * If the entry has never been written to, -1 is returned and errno is set to
    * ENOMSG.
    *
-   * The optimization using the optional always_update_entry parameter reduces
-   * copying when the entry is not updated. This optiziation assumes that
-   * the caller keeps the previous value in memory, as a static variable or
-   * class member.
+   * Setting the always_update_entry parameter to false prevents copying the
+   * entry if it is not updated with a new value. A suggested pattern is keeping
+   * the previous value in memory, as a static variable or class member.
    *
    * @param entry The storage object to read into
    * @param state The state object to keep track of the read

--- a/tyndall/ipc/seq_lock.h
+++ b/tyndall/ipc/seq_lock.h
@@ -1,9 +1,9 @@
 /*
 seq_lock.h
 
-Sequence lock: https://en.wikipedia.org/wiki/Seqlock, https://lwn.net/Articles/21355/
-Supports single writer, multiple readers
-Reader always gets the most recent entry
+Sequence lock: https://en.wikipedia.org/wiki/Seqlock,
+https://lwn.net/Articles/21355/ Supports single writer, multiple readers Reader
+always gets the most recent entry
 
 Inspired by:
 http://www.1024cores.net/home/lock-free-algorithms/reader-writer-problem/improved-lock-free-seqlock
@@ -12,12 +12,12 @@ https://github.com/rigtorp/Seqlock
 */
 
 #pragma once
+#include "smp.h"
 #include <assert.h>
 #include <errno.h>
-#include "smp.h"
 
-__attribute__((always_inline)) static inline unsigned seq_lock_write_begin(unsigned* seq)
-{
+__attribute__((always_inline)) static inline unsigned
+seq_lock_write_begin(unsigned *seq) {
   unsigned seq1 = *seq;
 
   smp_write_once(*seq, ++seq1);
@@ -26,16 +26,16 @@ __attribute__((always_inline)) static inline unsigned seq_lock_write_begin(unsig
   return seq1;
 }
 
-__attribute__((always_inline)) static inline void seq_lock_write_end(unsigned* seq, unsigned seq1)
-{
+__attribute__((always_inline)) static inline void
+seq_lock_write_end(unsigned *seq, unsigned seq1) {
   smp_wmb();
   smp_write_once(*seq, ++seq1);
 }
 
-__attribute__((always_inline)) static inline unsigned seq_lock_read_begin(unsigned* seq)
-{
+__attribute__((always_inline)) static inline unsigned
+seq_lock_read_begin(unsigned *seq) {
   unsigned seq1;
-  while((seq1 = smp_read_once(*seq)) & 1)
+  while ((seq1 = smp_read_once(*seq)) & 1)
     cpu_relax();
 
   smp_rmb();
@@ -43,27 +43,22 @@ __attribute__((always_inline)) static inline unsigned seq_lock_read_begin(unsign
   return seq1;
 }
 
-__attribute__((always_inline)) static inline unsigned seq_lock_read_retry(unsigned* seq, unsigned seq1)
-{
+__attribute__((always_inline)) static inline unsigned
+seq_lock_read_retry(unsigned *seq, unsigned seq1) {
   smp_rmb();
   unsigned seq2 = smp_read_once(*seq);
 
   return seq2 != seq1;
 }
 
-
 #ifdef __cplusplus
 
-
-struct seq_lock_state
-{
+struct seq_lock_state {
   unsigned prev_seq = 0;
   bool has_read_once = false;
 };
 
-template<typename STORAGE>
-struct seq_lock
-{
+template <typename STORAGE> struct seq_lock {
   static_assert(std::is_nothrow_copy_assignable_v<STORAGE>);
   static_assert(std::is_trivially_copy_assignable_v<STORAGE>);
 
@@ -74,12 +69,10 @@ struct seq_lock
   STORAGE entry;
 
 public:
-
   using storage = STORAGE;
   using state = seq_lock_state;
 
-  void write(const STORAGE& entry, seq_lock_state&)
-  {
+  void write(const STORAGE &entry, seq_lock_state &) {
     unsigned seq = seq_lock_write_begin(&this->seq);
 
     this->entry = entry;
@@ -87,37 +80,30 @@ public:
     seq_lock_write_end(&this->seq, seq);
   }
 
-  int read(STORAGE& entry, seq_lock_state& state)
-  {
+  int read(STORAGE &entry, seq_lock_state &state) {
     int rc;
     unsigned seq1;
 
-    do
-    {
+    do {
       seq1 = seq_lock_read_begin(&this->seq);
       entry = this->entry;
 
     } while (seq_lock_read_retry(&this->seq, seq1));
 
-    if (seq1 != state.prev_seq)
-    {
+    if (seq1 != state.prev_seq) {
       rc = 0;
       state.prev_seq = seq1;
       if (!state.has_read_once)
         state.has_read_once = true;
-    }
-    else if ((seq1 == 0) && !state.has_read_once)
-    {
+    } else if ((seq1 == 0) && !state.has_read_once) {
       rc = -1;
       errno = ENOMSG;
-    }
-    else
-    {
+    } else {
       rc = -1;
       errno = EAGAIN;
     }
     return rc;
   }
-} __attribute__ ((aligned(CACHELINE_BYTES)));
+} __attribute__((aligned(CACHELINE_BYTES)));
 
 #endif

--- a/tyndall/ipc/shmem.h
+++ b/tyndall/ipc/shmem.h
@@ -88,7 +88,7 @@ concept shmem_data_structure = requires(
   }
   -> std::same_as<void>; // void return type since we don't expect fail on send
   {
-    ds.read(storage, state)
+    ds.read(storage, state, true)
   } -> std::same_as<int>; // return value: 0 is success, -1 is error, errno is
                           // ENOMSG, EAGAIN
 
@@ -176,9 +176,9 @@ public:
     data_structure().write(entry, state);
   }
 
-  int read(storage &entry) noexcept {
+  int read(storage &entry, bool always_update_entry = true) noexcept {
     static_assert(PERMISSIONS & SHMEM_READ, "needs read permission");
-    return data_structure().read(entry, state);
+    return data_structure().read(entry, state, always_update_entry);
   }
 
   // disable copy

--- a/tyndall/log/log.cpp
+++ b/tyndall/log/log.cpp
@@ -3,64 +3,53 @@
 #define LOG_PRINTF
 #include "log.h"
 
-void log_flush_impl()
-{
-  fflush(stdout);
-}
+void log_flush_impl() { fflush(stdout); }
 
-const char* to_string(log_level_t lvl)
-{
-  switch(lvl)
-  {
-    case log_level_error:
-      return "error";
-    case log_level_warning:
-      return "warning";
-    case log_level_info:
-      return "info";
-    case log_level_debug:
-      return "debug";
-    default:
-      return "unknown";
+const char *to_string(log_level_t lvl) {
+  switch (lvl) {
+  case log_level_error:
+    return "error";
+  case log_level_warning:
+    return "warning";
+  case log_level_info:
+    return "info";
+  case log_level_debug:
+    return "debug";
+  default:
+    return "unknown";
   }
 }
 
-const char* to_color_string(log_level_t lvl)
-{
-  switch(lvl)
-  {
-    case log_level_error:
-      return log_color_red log_color_bold "error" log_color_reset;
-    case log_level_warning:
-      return log_color_yellow log_color_bold "warning" log_color_reset;
-    case log_level_info:
-      return log_color_cyan log_color_bold "info" log_color_reset;
-    case log_level_debug:
-      return log_color_green log_color_bold "debug" log_color_reset;
-    default:
-      return "unknown";
+const char *to_color_string(log_level_t lvl) {
+  switch (lvl) {
+  case log_level_error:
+    return log_color_red log_color_bold "error" log_color_reset;
+  case log_level_warning:
+    return log_color_yellow log_color_bold "warning" log_color_reset;
+  case log_level_info:
+    return log_color_cyan log_color_bold "info" log_color_reset;
+  case log_level_debug:
+    return log_color_green log_color_bold "debug" log_color_reset;
+  default:
+    return "unknown";
   }
 }
 
-log_level_t log_level(const char* cat)
-{
+log_level_t log_level(const char *cat) {
   log_level_t ref_lvl = (log_level_t)-1;
   const char *env = getenv("LOG_LEVEL");
-  if (env)
-  {
-    if ((cat == NULL) || strlen(cat) == 0)
-    {
-      for (int i=(int)log_level_debug; i <= (int)log_level_error; ++i)
-        if (strncmp(env, to_string((log_level_t)i), strlen(to_string((log_level_t)i))) == 0)
+  if (env) {
+    if ((cat == NULL) || strlen(cat) == 0) {
+      for (int i = (int)log_level_debug; i <= (int)log_level_error; ++i)
+        if (strncmp(env, to_string((log_level_t)i),
+                    strlen(to_string((log_level_t)i))) == 0)
           ref_lvl = (log_level_t)i;
 
       if ((int)ref_lvl == -1)
         ref_lvl = log_level_info;
-    }
-    else
-    {
-      for (const char* e = env; (e != NULL) && (e[1] != '\0'); e = strchr(e+1, ','))
-      {
+    } else {
+      for (const char *e = env; (e != NULL) && (e[1] != '\0');
+           e = strchr(e + 1, ',')) {
         if (*e == ',')
           ++e;
 
@@ -73,22 +62,20 @@ log_level_t log_level(const char* cat)
           const char *cat_match = cat;
           const char *glob;
 
-          do
-          {
+          do {
             glob = strchr(glob_start, '*') ?: strchr(glob_start, ':') ?: strchr(glob_start, ',') ?: strchr(glob_start, '\0');
 
             if (glob_start == e) // first iteration
             {
-              if (strncmp(glob_start, cat_match, static_cast<size_t>(glob - glob_start)) != 0)
+              if (strncmp(glob_start, cat_match,
+                          static_cast<size_t>(glob - glob_start)) != 0)
                 matches = false;
-            }
-            else
-            {
+            } else {
               bool cat_match_matches = false;
-              for (const char* c = cat_match; !cat_match_matches && (*c != '\0'); ++c)
-              {
-                if (strncmp(c, glob_start, static_cast<size_t>(glob - glob_start)) == 0)
-                {
+              for (const char *c = cat_match;
+                   !cat_match_matches && (*c != '\0'); ++c) {
+                if (strncmp(c, glob_start,
+                            static_cast<size_t>(glob - glob_start)) == 0) {
                   cat_match_matches = true;
                   cat_match = c;
                 }
@@ -99,21 +86,19 @@ log_level_t log_level(const char* cat)
 
             cat_match += glob - glob_start;
             glob_start = glob + 1;
-          }
-          while (*glob == '*');
+          } while (*glob == '*');
 
           // check tail
           if ((glob[-1] != '*') && (cat_match - cat != (int)strlen(cat)))
             matches = false;
         }
 
-        if (matches)
-        {
-          if ((colon != NULL) && (colon[1] != '\0')
-            && ((comma == NULL) || (comma > colon)))
-          {
-            for (int i=(int)log_level_debug; i <= (int)log_level_error; ++i)
-              if (strncmp(colon+1, to_string((log_level_t)i), strlen(to_string((log_level_t)i))) == 0)
+        if (matches) {
+          if ((colon != NULL) && (colon[1] != '\0') &&
+              ((comma == NULL) || (comma > colon))) {
+            for (int i = (int)log_level_debug; i <= (int)log_level_error; ++i)
+              if (strncmp(colon + 1, to_string((log_level_t)i),
+                          strlen(to_string((log_level_t)i))) == 0)
                 ref_lvl = (log_level_t)i;
           }
         }
@@ -122,8 +107,7 @@ log_level_t log_level(const char* cat)
       if ((int)ref_lvl == -1)
         ref_lvl = log_level("");
     }
-  }
-  else
+  } else
     ref_lvl = log_level_info;
 
   return ref_lvl;

--- a/tyndall/log/log.h
+++ b/tyndall/log/log.h
@@ -8,16 +8,16 @@
 */
 
 #ifdef __cplusplus
-#include <string>
-#include <cstring>
-#include <utility>
 #include <cassert>
+#include <cstring>
+#include <string>
+#include <utility>
 #else
+#include <assert.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <string.h>
-#include <assert.h>
 #endif
 
 // interface
@@ -29,122 +29,152 @@
 
 #define log_cat_log(cat, lvl, fmt, ...) log_impl(fmt, lvl, cat, __VA_ARGS__)
 #define log_cat_error(cat, ...) log_cat_log(cat, log_level_error, __VA_ARGS__)
-#define log_cat_warning(cat, ...) log_cat_log(cat, log_level_warning, __VA_ARGS__)
+#define log_cat_warning(cat, ...)                                              \
+  log_cat_log(cat, log_level_warning, __VA_ARGS__)
 #define log_cat_info(cat, ...) log_cat_log(cat, log_level_info, __VA_ARGS__)
 #define log_cat_debug(cat, ...) log_cat_log(cat, log_level_debug, __VA_ARGS__)
 
-#define log_init(...) do{}while(0)
+#define log_init(...)                                                          \
+  do {                                                                         \
+  } while (0)
 #define log_str log_str_impl
 #define log_flush log_flush_impl
 #define log_level log_level_impl
 
-#define log_once(log_func, ...) do{ \
-  static int run = 1; \
-  if (run) \
-  { \
-    log_func(__VA_ARGS__); \
-    run = 0; \
-  } \
-} while(0)
+#define log_once(log_func, ...)                                                \
+  do {                                                                         \
+    static int run = 1;                                                        \
+    if (run) {                                                                 \
+      log_func(__VA_ARGS__);                                                   \
+      run = 0;                                                                 \
+    }                                                                          \
+  } while (0)
 
-#define log_once_error(...)   log_once(log_error, __VA_ARGS__)
+#define log_once_error(...) log_once(log_error, __VA_ARGS__)
 #define log_once_warning(...) log_once(log_warning, __VA_ARGS__)
-#define log_once_info(...)    log_once(log_info, __VA_ARGS__)
-#define log_once_debug(...)   log_once(log_debug, __VA_ARGS__)
+#define log_once_info(...) log_once(log_info, __VA_ARGS__)
+#define log_once_debug(...) log_once(log_debug, __VA_ARGS__)
 
-#define log_cat_once_error(...)   log_once(log_cat_error, __VA_ARGS__)
+#define log_cat_once_error(...) log_once(log_cat_error, __VA_ARGS__)
 #define log_cat_once_warning(...) log_once(log_cat_warning, __VA_ARGS__)
-#define log_cat_once_info(...)    log_once(log_cat_info, __VA_ARGS__)
-#define log_cat_once_debug(...)   log_once(log_cat_debug, __VA_ARGS__)
+#define log_cat_once_info(...) log_once(log_cat_info, __VA_ARGS__)
+#define log_cat_once_debug(...) log_once(log_cat_debug, __VA_ARGS__)
 
-#define log_errno(fmt, ...) log_error("[" log_color_red log_color_bold "errno" log_color_reset ": " LOG_PATTERN_STR "] " fmt, strerror(errno) __VA_OPT__(,) __VA_ARGS__)
+#define log_errno(fmt, ...)                                                    \
+  log_error("[" log_color_red log_color_bold "errno" log_color_reset           \
+            ": " LOG_PATTERN_STR "] " fmt,                                     \
+            strerror(errno) __VA_OPT__(, ) __VA_ARGS__)
 
-#define log_flushed_error(...) do{ log_error(__VA_ARGS__); log_flush(); } while(0)
-#define log_flushed_warning(...) do{ log_warning(__VA_ARGS__); log_flush(); } while(0)
-#define log_flushed_info(...) do{ log_info(__VA_ARGS__); log_flush(); } while(0)
-#define log_flushed_debug(...) do{ log_debug(__VA_ARGS__); log_flush(); } while(0)
-
+#define log_flushed_error(...)                                                 \
+  do {                                                                         \
+    log_error(__VA_ARGS__);                                                    \
+    log_flush();                                                               \
+  } while (0)
+#define log_flushed_warning(...)                                               \
+  do {                                                                         \
+    log_warning(__VA_ARGS__);                                                  \
+    log_flush();                                                               \
+  } while (0)
+#define log_flushed_info(...)                                                  \
+  do {                                                                         \
+    log_info(__VA_ARGS__);                                                     \
+    log_flush();                                                               \
+  } while (0)
+#define log_flushed_debug(...)                                                 \
+  do {                                                                         \
+    log_debug(__VA_ARGS__);                                                    \
+    log_flush();                                                               \
+  } while (0)
 
 // colors
-#define log_color_red     "\033[31m"
-#define log_color_green   "\033[32m"
-#define log_color_yellow  "\033[33m"
-#define log_color_blue    "\033[34m"
+#define log_color_red "\033[31m"
+#define log_color_green "\033[32m"
+#define log_color_yellow "\033[33m"
+#define log_color_blue "\033[34m"
 #define log_color_magenta "\033[35m"
-#define log_color_cyan    "\033[36m"
-#define log_color_reset   "\033[0m"
-#define log_color_bold    "\033[1m"
-
+#define log_color_cyan "\033[36m"
+#define log_color_reset "\033[0m"
+#define log_color_bold "\033[1m"
 
 // implementation
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-typedef enum { log_level_debug, log_level_info, log_level_warning, log_level_error } log_level_t;
+typedef enum {
+  log_level_debug,
+  log_level_info,
+  log_level_warning,
+  log_level_error
+} log_level_t;
 
-const char* to_color_string(log_level_t lvl);
+const char *to_color_string(log_level_t lvl);
 
-  /*
-    Reads the log level from the LOG_LEVEL environment variable.
-    Optional global / fallback level first, then key-values of categories and debug level.
-    Default category is function name.
-    Examples:
-      LOG_LEVEL=error ./my_program
-      LOG_LEVEL=error,my_category:debug ./my_program
-      LOG_LEVEL=my_ca*e*ry:info ./my_program
-  */
-  log_level_t log_level(const char* cat);
+/*
+  Reads the log level from the LOG_LEVEL environment variable.
+  Optional global / fallback level first, then key-values of categories and
+  debug level. Default category is function name. Examples: LOG_LEVEL=error
+  ./my_program LOG_LEVEL=error,my_category:debug ./my_program
+    LOG_LEVEL=my_ca*e*ry:info ./my_program
+*/
+log_level_t log_level(const char *cat);
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#define log_impl(fmt, lvl, category, ...) \
-do { \
-  const char *cat = (const char*)((category && strlen(category)) ? category : __FUNCTION__); \
-  \
-  log_format_impl(fmt, lvl, cat, __VA_ARGS__); \
-} while(0)
+#define log_impl(fmt, lvl, category, ...)                                      \
+  do {                                                                         \
+    const char *cat =                                                          \
+        (const char *)((category && strlen(category)) ? category               \
+                                                      : __FUNCTION__);         \
+                                                                               \
+    log_format_impl(fmt, lvl, cat, __VA_ARGS__);                               \
+  } while (0)
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-  #define log_str_impl(str, lvl, cat) do{if(lvl >= log_level(cat)) printf("[%s %s:%d " log_color_magenta "%s" log_color_reset "] %s", to_color_string(lvl), __FILE__, __LINE__, cat, str);}while(0)
+#define log_str_impl(str, lvl, cat)                                            \
+  do {                                                                         \
+    if (lvl >= log_level(cat))                                                 \
+      printf("[%s %s:%d " log_color_magenta "%s" log_color_reset "] %s",       \
+             to_color_string(lvl), __FILE__, __LINE__, cat, str);              \
+  } while (0)
 
-  void log_flush_impl();
+void log_flush_impl();
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
 #if defined(LOG_FMT)
-  #ifndef __cplusplus
-    #error fmt formatting is only available for C++, not C
-  #endif
+#ifndef __cplusplus
+#error fmt formatting is only available for C++, not C
+#endif
 
-  #include <fmt/format.h>
-  #include <fmt/ostream.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
-  #define log_format_impl(_fmt, lvl, cat, ...) do { \
-    std::string str = fmt::format(_fmt __VA_OPT__(,) __VA_ARGS__); \
-    log_str_impl(str.c_str(), lvl, cat); \
-  } while(0)
+#define log_format_impl(_fmt, lvl, cat, ...)                                   \
+  do {                                                                         \
+    std::string str = fmt::format(_fmt __VA_OPT__(, ) __VA_ARGS__);            \
+    log_str_impl(str.c_str(), lvl, cat);                                       \
+  } while (0)
 
-  #define LOG_PATTERN_STR "{}"
+#define LOG_PATTERN_STR "{}"
 
 #elif defined(LOG_PRINTF)
 
-  #define log_format_impl(fmt, lvl, cat, ...) do { \
-    char buf[1024]; \
-    snprintf(buf, sizeof(buf), fmt __VA_OPT__(,) __VA_ARGS__); \
-    log_str_impl(buf, lvl, cat); \
-  } while(0)
+#define log_format_impl(fmt, lvl, cat, ...)                                    \
+  do {                                                                         \
+    char buf[1024];                                                            \
+    snprintf(buf, sizeof(buf), fmt __VA_OPT__(, ) __VA_ARGS__);                \
+    log_str_impl(buf, lvl, cat);                                               \
+  } while (0)
 
-  #define LOG_PATTERN_STR "%s"
+#define LOG_PATTERN_STR "%s"
 
 #else
-  #error You need to specify either LOG_FMT or LOG_PRINTF
+#error You need to specify either LOG_FMT or LOG_PRINTF
 #endif

--- a/tyndall/meta/hash.h
+++ b/tyndall/meta/hash.h
@@ -1,27 +1,25 @@
 #pragma once
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 // FNV-1a 32bit hashing algorithm.
-constexpr uint32_t hash_fnv1a_32(const char* s, size_t count) noexcept
-{
-  return count ? (((hash_fnv1a_32(s, count-1)) ^ static_cast<uint32_t>(s[count-1])) * 16777619u) : 2166136261u;
+constexpr uint32_t hash_fnv1a_32(const char *s, size_t count) noexcept {
+  return count ? (((hash_fnv1a_32(s, count - 1)) ^
+                   static_cast<uint32_t>(s[count - 1])) *
+                  16777619u)
+               : 2166136261u;
 }
 
-constexpr uint32_t operator ""_hash_fnv1a_32(const char* s, size_t size) noexcept
-{
+constexpr uint32_t operator""_hash_fnv1a_32(const char *s,
+                                            size_t size) noexcept {
   return hash_fnv1a_32(s, size);
 }
 
-template<typename STRING>
-constexpr uint32_t hash_fnv1a_32(STRING s) noexcept
-{
+template <typename STRING> constexpr uint32_t hash_fnv1a_32(STRING s) noexcept {
   return hash_fnv1a_32(s.c_str(), s.length());
 }
 
-template<typename STRING>
-constexpr uint32_t hash_fnv1a_32() noexcept
-{
+template <typename STRING> constexpr uint32_t hash_fnv1a_32() noexcept {
   return hash_fnv1a_32(STRING::c_str(), STRING::length());
 }

--- a/tyndall/meta/iterate.h
+++ b/tyndall/meta/iterate.h
@@ -6,10 +6,9 @@
   Useful for iterating recursively at compile time.
 */
 
-template<int index, typename Function>
-requires(index >= 1)
-constexpr void iterate_impl(Function f) noexcept
-{
+template <int index, typename Function>
+  requires(index >= 1)
+constexpr void iterate_impl(Function f) noexcept {
   constexpr int prev_index = index - 1;
 
   iterate<prev_index>(f);
@@ -17,23 +16,19 @@ constexpr void iterate_impl(Function f) noexcept
   f(std::integral_constant<int, prev_index>());
 }
 
-template<int index, typename Function>
-requires(index == 0)
-constexpr void iterate_impl(Function f) noexcept
-{
-}
+template <int index, typename Function>
+  requires(index == 0)
+constexpr void iterate_impl(Function f) noexcept {}
 
-template<typename Function>
-concept iterable = requires(Function function)
-{
+template <typename Function>
+concept iterable = requires(Function function) {
   function(std::integral_constant<int, 0>{});
   function(std::integral_constant<int, 1>{});
   // we dont bother checking the rest of the integral constants
 };
 
-template<int index, typename Function>
-requires(iterable<Function>)
-constexpr void iterate(Function f) noexcept
-{
+template <int index, typename Function>
+  requires(iterable<Function>)
+constexpr void iterate(Function f) noexcept {
   return iterate_impl<index>(f);
 }

--- a/tyndall/meta/macro.h
+++ b/tyndall/meta/macro.h
@@ -4,15 +4,14 @@
 // http://saadahmad.ca/cc-preprocessor-metaprogramming-basic-pattern-matching-macros-and-conditionals/
 // https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms#deferred-expression
 
-
 #define M_MAX_ARITHMETIC 126 // Max number to be used in arithmetic
 
-#define M_EMPTY() 
+#define M_EMPTY()
 #define M_DEFER(...) __VA_ARGS__ M_EMPTY()
-#define M_DEFER2(...) __VA_ARGS__ M_DEFER(M_EMPTY) ()
-#define M_DEFER3(...) __VA_ARGS__ M_DEFER2(M_EMPTY) ()
-#define M_DEFER4(...) __VA_ARGS__ M_DEFER3(M_EMPTY) ()
-#define M_DEFER5(...) __VA_ARGS__ M_DEFER4(M_EMPTY) ()
+#define M_DEFER2(...) __VA_ARGS__ M_DEFER(M_EMPTY)()
+#define M_DEFER3(...) __VA_ARGS__ M_DEFER2(M_EMPTY)()
+#define M_DEFER4(...) __VA_ARGS__ M_DEFER3(M_EMPTY)()
+#define M_DEFER5(...) __VA_ARGS__ M_DEFER4(M_EMPTY)()
 
 #define M_EVAL_1(...) __VA_ARGS__
 #define M_EVAL_2(...) M_EVAL_1(M_EVAL_1(__VA_ARGS__))
@@ -27,16 +26,16 @@
 #define M_EAT(...)
 #define M_EXPAND(...) __VA_ARGS__
 #define M_OBSTRUCT(...) __VA_ARGS__ M_DEFER(M_EMPTY)()
- 
+
 #define M_ENCLOSE_EXPAND(...) EXPANDED, ENCLOSED, (__VA_ARGS__) ) M_EAT (
-#define M_GET_CAT_EXP(a, b) (a, M_ENCLOSE_EXPAND b, DEFAULT, b )
+#define M_GET_CAT_EXP(a, b) (a, M_ENCLOSE_EXPAND b, DEFAULT, b)
 
 #define M_CAT_WITH_ENCLOSED(a, b) a b
-#define M_CAT_WITH_DEFAULT(a, b) a ## b
-#define M_CAT_WITH(a, _, f, b) M_CAT_WITH_ ## f (a, b)
+#define M_CAT_WITH_DEFAULT(a, b) a##b
+#define M_CAT_WITH(a, _, f, b) M_CAT_WITH_##f(a, b)
 
 #define M_EVAL_CAT_WITH(...) M_CAT_WITH __VA_ARGS__
-#define M_CAT(a, b) M_EVAL_CAT_WITH ( M_GET_CAT_EXP(a, b) )
+#define M_CAT(a, b) M_EVAL_CAT_WITH(M_GET_CAT_EXP(a, b))
 
 #define M_HEAD(x, ...) x
 #define M_HEAD1(x, y, ...) y
@@ -45,7 +44,7 @@
 #define M_TAIL(x, ...) __VA_ARGS__
 #define M_TAIL1(x, y, ...) __VA_ARGS__
 #define M_TAIL2(x, y, z, ...) __VA_ARGS__
- 
+
 #define _M_STRINGIFY(x) #x
 #define M_STRINGIFY(x) _M_STRINGIFY(x)
 
@@ -55,33 +54,32 @@
 
 // for range stuff:
 #define M_EXPAND_TEST_EXISTS(...) EXPANDED, EXISTS(__VA_ARGS__) ) M_EAT (
-#define M_GET_TEST_EXISTS_RESULT(x) ( CAT(EXPAND_TEST_, x),  DOESNT_EXIST )
- 
+#define M_GET_TEST_EXISTS_RESULT(x) (CAT(EXPAND_TEST_, x), DOESNT_EXIST)
+
 #define M_GET_TEST_EXIST_VALUE_(expansion, existValue) existValue
-#define M_GET_TEST_EXIST_VALUE(x) M_GET_TEST_EXIST_VALUE_  x 
- 
-#define M_TEST_EXISTS(x) M_GET_TEST_EXIST_VALUE (  M_GET_TEST_EXISTS_RESULT(x) )
+#define M_GET_TEST_EXIST_VALUE(x) M_GET_TEST_EXIST_VALUE_ x
+
+#define M_TEST_EXISTS(x) M_GET_TEST_EXIST_VALUE(M_GET_TEST_EXISTS_RESULT(x))
 
 #define M_DOES_VALUE_EXIST_EXISTS(...) 1
 #define M_DOES_VALUE_EXIST_DOESNT_EXIST 0
 #define M_DOES_VALUE_EXIST(x) M_CAT(M_DOES_VALUE_EXIST_, x)
- 
+
 #define M_EXTRACT_VALUE_EXISTS(...) __VA_ARGS__
 #define M_EXTRACT_VALUE(value) M_CAT(M_EXTRACT_VALUE_, value)
- 
-#define M_TRY_EXTRACT_EXISTS(value, ...) \
-  M_IF ( M_DOES_VALUE_EXIST(M_TEST_EXISTS(value)) )\
-  ( M_EXTRACT_VALUE(value), __VA_ARGS__ )
 
+#define M_TRY_EXTRACT_EXISTS(value, ...)                                       \
+  M_IF(M_DOES_VALUE_EXIST(M_TEST_EXISTS(value)))                               \
+  (M_EXTRACT_VALUE(value), __VA_ARGS__)
 
 #define M_NOT_0 EXISTS(1)
-#define M_NOT(x) M_TRY_EXTRACT_EXISTS ( CAT(NOT_, x), 0 )
+#define M_NOT(x) M_TRY_EXTRACT_EXISTS(CAT(NOT_, x), 0)
 
 #define M_IF_1(true, ...) true
 #define M_IF_0(true, ...) __VA_ARGS__
 #define M_IF(value) M_CAT(M_IF_, value)
 
-#define M_PRIMITIVE_CAT(a, ...) a ## __VA_ARGS__
+#define M_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
 #define M_BITAND(x) M_PRIMITIVE_CAT(M_BITAND_, x)
 #define M_BITAND_0(y) 0
 #define M_BITAND_1(y) y
@@ -91,59 +89,36 @@
 #define M_COMPL_1 0
 
 #define M_CHECK_N(x, n, ...) n
-#define M_CHECK(...) M_CHECK_N(__VA_ARGS__, 0,)
+#define M_CHECK(...) M_CHECK_N(__VA_ARGS__, 0, )
 #define M_PROBE(x) x, 1,
 
 #define M_IS_PAREN(x) M_CHECK(M_IS_PAREN_PROBE x)
 #define M_IS_PAREN_PROBE(...) M_PROBE(~)
 
-#define M_PRIMITIVE_COMPARE(x, y) M_IS_PAREN \
-( \
-M_COMPARE_ ## x ( M_COMPARE_ ## y) (())  \
-)
+#define M_PRIMITIVE_COMPARE(x, y) M_IS_PAREN(M_COMPARE_##x(M_COMPARE_##y)(()))
 
-#define M_IS_COMPARABLE(x) M_IS_PAREN( M_CAT(M_COMPARE_, x) (()) )
+#define M_IS_COMPARABLE(x) M_IS_PAREN(M_CAT(M_COMPARE_, x)(()))
 
-#define M_NOT_EQUAL(x, y) \
-M_IF(M_BITAND(M_IS_COMPARABLE(x))(M_IS_COMPARABLE(y)) ) \
-( \
-  M_PRIMITIVE_COMPARE, \
-  1 M_EAT \
-)(x, y)
+#define M_NOT_EQUAL(x, y)                                                      \
+  M_IF(M_BITAND(M_IS_COMPARABLE(x))(M_IS_COMPARABLE(y)))                       \
+  (M_PRIMITIVE_COMPARE, 1 M_EAT)(x, y)
 
 // M_RANGE example:
-//#define PR(i, _) printf("iteration: %d\n", i);
+// #define PR(i, _) printf("iteration: %d\n", i);
 //_RANGE(PR, 0, 8))
-#define M_RANGE(macro, start, end, ...) \
-  M_IF(M_NOT_EQUAL(start, end)) \
-  ( \
-    M_OBSTRUCT(M_RANGE_INDIRECT) () \
-    ( \
-        macro, start, M_DEC(end), __VA_ARGS__ \
-    ) \
-    M_OBSTRUCT(macro) \
-    ( \
-        M_DEC(end), __VA_ARGS__ \
-    ) \
-  )
+#define M_RANGE(macro, start, end, ...)                                        \
+  M_IF(M_NOT_EQUAL(start, end))                                                \
+  (M_OBSTRUCT(M_RANGE_INDIRECT)()(macro, start, M_DEC(end),                    \
+                                  __VA_ARGS__)M_OBSTRUCT(macro)(M_DEC(end),    \
+                                                                __VA_ARGS__))
 #define M_RANGE_INDIRECT() M_RANGE
 
-#define M_RANGE_WITH_COMMA(macro, start, end, ...) \
-  M_IF(M_NOT_EQUAL(start, end)) \
-  ( \
-    M_OBSTRUCT(M_RANGE_WITH_COMMA_INDIRECT) () \
-    ( \
-        macro, start, M_DEC(end), __VA_ARGS__ \
-    ) \
-    M_IF(M_NOT_EQUAL(start, M_DEC(end))) \
-    ( \
-      M_EXPAND(,) \
-    ) \
-    M_OBSTRUCT(macro) \
-    ( \
-        M_DEC(end), __VA_ARGS__ \
-    ) \
-  )
+#define M_RANGE_WITH_COMMA(macro, start, end, ...)                             \
+  M_IF(M_NOT_EQUAL(start, end))                                                \
+  (M_OBSTRUCT(M_RANGE_WITH_COMMA_INDIRECT)()(                                  \
+      macro, start, M_DEC(end),                                                \
+      __VA_ARGS__)M_IF(M_NOT_EQUAL(start, M_DEC(end)))(M_EXPAND(, ))           \
+       M_OBSTRUCT(macro)(M_DEC(end), __VA_ARGS__))
 #define M_RANGE_WITH_COMMA_INDIRECT() M_RANGE_WITH_COMMA
 
 #define M_COMPARE_0(x) x
@@ -275,7 +250,7 @@ M_IF(M_BITAND(M_IS_COMPARABLE(x))(M_IS_COMPARABLE(y)) ) \
 #define M_COMPARE_126(x) x
 #define M_COMPARE_127(x) x
 
-//#define DEC_0 127
+// #define DEC_0 127
 #define M_DEC_1 0
 #define M_DEC_2 1
 #define M_DEC_3 2

--- a/tyndall/meta/static_warn.h
+++ b/tyndall/meta/static_warn.h
@@ -2,15 +2,16 @@
 #include <tyndall/meta/macro.h>
 #include <type_traits>
 
-namespace static_warn_detail
-{
-  template <int test> struct converter : public std::true_type {};
-  template <> struct converter<0> : public std::false_type {};
-}
+namespace static_warn_detail {
+template <int test> struct converter : public std::true_type {};
+template <> struct converter<0> : public std::false_type {};
+} // namespace static_warn_detail
 
-#define static_warn(cond, msg) \
-struct M_CAT(static_warning,__LINE__) { \
-  void _(std::false_type const& ) __attribute__((deprecated(msg))) {}; \
-  void _(std::true_type const& ) {}; \
-  M_CAT(static_warning,__LINE__)() {_(static_warn_detail::converter<(cond)>());} \
-}
+#define static_warn(cond, msg)                                                 \
+  struct M_CAT(static_warning, __LINE__) {                                     \
+    void _(std::false_type const &) __attribute__((deprecated(msg))) {};       \
+    void _(std::true_type const &) {};                                         \
+    M_CAT(static_warning, __LINE__)() {                                        \
+      _(static_warn_detail::converter<(cond)>());                              \
+    }                                                                          \
+  }

--- a/tyndall/meta/strval.h
+++ b/tyndall/meta/strval.h
@@ -1,157 +1,122 @@
 #pragma once
 
-// compile time string which ensures "string A"_strval and "string A"_strval have the same type,
-// while "string A"_strval and "string B"_strval have different types
+// compile time string which ensures "string A"_strval and "string A"_strval
+// have the same type, while "string A"_strval and "string B"_strval have
+// different types
 
 #include <type_traits>
 
-template<char... Chars>
-struct strval
-{
-};
+template <char... Chars> struct strval {};
 
-template<char Lhs, char... Rhs>
-struct strval<Lhs, Rhs...>
-{
-  template<char... Args>
-  constexpr auto operator+(strval<Args...> rhs) const noexcept
-  {
+template <char Lhs, char... Rhs> struct strval<Lhs, Rhs...> {
+  template <char... Args>
+  constexpr auto operator+(strval<Args...> rhs) const noexcept {
     return strval<Lhs, Rhs..., Args...>();
   }
 
-  static constexpr const char* c_str() noexcept
-  {
-    return (const char[]){ Lhs, Rhs..., '\0' };
+  static constexpr const char *c_str() noexcept {
+    return (const char[]){Lhs, Rhs..., '\0'};
   }
 
-  static constexpr int length() noexcept
-  {
-    return 1 + sizeof... (Rhs);
-  }
+  static constexpr int length() noexcept { return 1 + sizeof...(Rhs); }
 
-  static constexpr int occurrences(char c) noexcept
-  {
+  static constexpr int occurrences(char c) noexcept {
     return ((Lhs == c) ? 1 : 0) + strval<Rhs...>::occurrences(c);
   }
 
-  template<char pattern, char replacement>
-  static constexpr auto replace() noexcept
-  {
-    return strval<((Lhs == pattern) ? replacement : Lhs)>() + strval<Rhs...>::template replace<pattern, replacement>();
+  template <char pattern, char replacement>
+  static constexpr auto replace() noexcept {
+    return strval<((Lhs == pattern) ? replacement : Lhs)>() +
+           strval<Rhs...>::template replace<pattern, replacement>();
   }
 
-  template<char pattern>
-  static constexpr auto remove_leading() noexcept
-  {
+  template <char pattern> static constexpr auto remove_leading() noexcept {
     if constexpr (Lhs == pattern)
       return strval<Rhs...>::template remove_leading<pattern>();
     else
       return strval<Lhs, Rhs...>{};
   }
 
-  template<int index>
-  requires(index == 0)
-  static constexpr char get() noexcept
-  {
+  template <int index>
+    requires(index == 0)
+  static constexpr char get() noexcept {
     return Lhs;
   }
 
-  template<int index>
-  requires(index > 0)
-  static constexpr char get() noexcept
-  {
+  template <int index>
+    requires(index > 0)
+  static constexpr char get() noexcept {
     return strval<Rhs...>::template get<index - 1>();
   }
 
   // set is volatile because it only matters in reinterpret_cast situations
-  void set() volatile
-  {
-    const char tmp[] = { Lhs, Rhs... };
-    for (int i=0; i<length(); ++i)
+  void set() volatile {
+    const char tmp[] = {Lhs, Rhs...};
+    for (int i = 0; i < length(); ++i)
       data[i] = tmp[i];
   }
 
-  char data[length()] = { Lhs, Rhs... }; // actual storage
+  char data[length()] = {Lhs, Rhs...}; // actual storage
 
-  constexpr static inline bool is_strval(){ return true; }
+  constexpr static inline bool is_strval() { return true; }
 };
 
-template<>
-struct strval<>
-{
+template <> struct strval<> {
   char data[0]; // enforce zero size
 
-  template<char... Args>
-  constexpr auto operator+(strval<Args...> args) const noexcept
-  {
+  template <char... Args>
+  constexpr auto operator+(strval<Args...> args) const noexcept {
     return strval<Args...>();
   }
 
-  static constexpr const char* c_str() noexcept
-  {
-    return (const char[]){ '\0' };
-  }
+  static constexpr const char *c_str() noexcept { return (const char[]){'\0'}; }
 
-  static constexpr int length() noexcept
-  {
-    return 0;
-  }
+  static constexpr int length() noexcept { return 0; }
 
-  static constexpr int occurrences(char c) noexcept
-  {
-    return 0;
-  }
+  static constexpr int occurrences(char c) noexcept { return 0; }
 
-  template<char pattern, char replacement>
-  static constexpr auto replace() noexcept
-  {
+  template <char pattern, char replacement>
+  static constexpr auto replace() noexcept {
     return strval<>();
   }
 
-  template<char pattern>
-  static constexpr auto remove_leading() noexcept
-  {
+  template <char pattern> static constexpr auto remove_leading() noexcept {
     return strval<>{};
   }
 
-  void set() volatile
-  {
-  }
+  void set() volatile {}
 
-  constexpr static inline bool is_strval(){ return true; }
+  constexpr static inline bool is_strval() { return true; }
 };
 
-template<char... Lhs, char... Rhs>
-constexpr auto operator==(strval<Lhs...> lhs, strval<Rhs...> rhs) noexcept
-{
+template <char... Lhs, char... Rhs>
+constexpr auto operator==(strval<Lhs...> lhs, strval<Rhs...> rhs) noexcept {
   return std::is_same<strval<Lhs...>, strval<Rhs...>>();
 }
 
-template<char... Lhs, char... Rhs>
-constexpr auto operator!=(strval<Lhs...> lhs, strval<Rhs...> rhs) noexcept
-{
+template <char... Lhs, char... Rhs>
+constexpr auto operator!=(strval<Lhs...> lhs, strval<Rhs...> rhs) noexcept {
   return !(operator==(lhs, rhs));
 }
 
-template<typename Char, Char... Args>
-constexpr strval<Args...> operator""_strval() noexcept
-{
+template <typename Char, Char... Args>
+constexpr strval<Args...> operator""_strval() noexcept {
   return {};
 }
 
-template<unsigned remainder, unsigned... digits>
+template <unsigned remainder, unsigned... digits>
 struct to_strval : to_strval<remainder / 10, remainder % 10, digits...> {};
 
-template<unsigned... digits>
-struct to_strval<0, digits...> : strval<('0' + digits)...>{};
+template <unsigned... digits>
+struct to_strval<0, digits...> : strval<('0' + digits)...> {};
 
 #include <tyndall/meta/macro.h>
 #define create_strval(str) M_CAT(str, _strval)
 #define strval_t(str) decltype(M_CAT(str, _strval))
 
-//#include <ostream>
-//template<char... Args>
-//std::ostream& operator<<(std::ostream& os, const strval<Args...>& rhs)
+// #include <ostream>
+// template<char... Args>
+// std::ostream& operator<<(std::ostream& os, const strval<Args...>& rhs)
 //{
-//  return os << rhs.c_str();
-//}
+//   return os << rhs.c_str();
+// }

--- a/tyndall/meta/typeinfo.h
+++ b/tyndall/meta/typeinfo.h
@@ -1,22 +1,20 @@
 #pragma once
 
-#include <type_traits>
-#include <string_view>
-#include "strval.h"
 #include "hash.h"
 #include "macro.h"
+#include "strval.h"
+#include <string_view>
+#include <type_traits>
 
-template<typename Type>
-struct typeinfo_raw
-{
-  static constexpr uint32_t hash() noexcept
-  {
-    //printf("FUNC: %s\n\n", __PRETTY_FUNCTION__);
-    return hash_fnv1a_32(__PRETTY_FUNCTION__, std::string_view(__PRETTY_FUNCTION__).length());
+template <typename Type> struct typeinfo_raw {
+  static constexpr uint32_t hash() noexcept {
+    // printf("FUNC: %s\n\n", __PRETTY_FUNCTION__);
+    return hash_fnv1a_32(__PRETTY_FUNCTION__,
+                         std::string_view(__PRETTY_FUNCTION__).length());
   }
 };
 
-template<typename Type>
+template <typename Type>
 using typeinfo = typeinfo_raw<std::remove_cvref_t<Type>>;
 
 #define typeinfo_hash(T) typeinfo<T>::hash()

--- a/tyndall/meta/typevals.h
+++ b/tyndall/meta/typevals.h
@@ -5,95 +5,68 @@
   typevals is a container with entries that have different types
 */
 
-template<typename... Types>
-class typevals
-{};
+template <typename... Types> class typevals {};
 
-template<typename Type, typename... Tail>
-struct typevals<Type, Tail...> : public typevals<Tail...>
-{
+template <typename Type, typename... Tail>
+struct typevals<Type, Tail...> : public typevals<Tail...> {
   Type val;
 
   explicit constexpr typevals(typevals<Tail...> tl, Type val) noexcept
-  : typevals<Tail...>(tl)
-  , val(val)
-  {}
+      : typevals<Tail...>(tl), val(val) {}
 
-  template<typename Entry>
+  template <typename Entry>
   constexpr typevals<Entry, Type, Tail...>
-  operator+(Entry entry) const noexcept
-  {
+  operator+(Entry entry) const noexcept {
     return typevals<Entry, Type, Tail...>(*this, entry);
   }
 
-  template<int index>
-  requires(index == sizeof...(Tail))
-  constexpr const Type& get() const noexcept
-  {
+  template <int index>
+    requires(index == sizeof...(Tail))
+  constexpr const Type &get() const noexcept {
     return val;
   }
 
-  template<int index>
-  requires(index < sizeof...(Tail))
+  template <int index>
+    requires(index < sizeof...(Tail))
   constexpr decltype(typevals<Tail...>::template get_type<index>())
-  get() const noexcept
-  {
+  get() const noexcept {
     return typevals<Tail...>::template get<index>();
   }
 
-  template<int index>
+  template <int index>
   constexpr decltype(typevals<Type, Tail...>::template get_type<index>())
-  operator[](std::integral_constant<int, index>) const noexcept
-  {
+  operator[](std::integral_constant<int, index>) const noexcept {
     return get<index>();
   }
 
-  static constexpr int size() noexcept
-  {
-    return 1 + sizeof...(Tail);
-  }
+  static constexpr int size() noexcept { return 1 + sizeof...(Tail); }
 
 protected:
-
   // get_type is a static helper for determining return type of get
-  template<int index>
-  requires(index == sizeof...(Tail))
-  static constexpr const Type&
-  get_type() noexcept
-  {
+  template <int index>
+    requires(index == sizeof...(Tail))
+  static constexpr const Type &get_type() noexcept {
     return Type();
   }
 
-  template<int index>
-  requires(index < sizeof...(Tail))
+  template <int index>
+    requires(index < sizeof...(Tail))
   static constexpr decltype(typevals<Tail...>::template get_type<index>())
-  get_type() noexcept
-  {
+  get_type() noexcept {
     return typevals<Tail...>::template get_type<index>();
   }
 };
 
-template<>
-struct typevals<>
-{
-  explicit constexpr typevals() noexcept
-  {}
+template <> struct typevals<> {
+  explicit constexpr typevals() noexcept {}
 
-  template<typename Entry>
-  constexpr typevals<Entry> operator+(Entry entry) const noexcept
-  {
+  template <typename Entry>
+  constexpr typevals<Entry> operator+(Entry entry) const noexcept {
     return typevals<Entry>(*this, entry);
   }
 
-  static constexpr int size() noexcept
-  {
-    return 0;
-  }
+  static constexpr int size() noexcept { return 0; }
 
 protected:
-  template<int index>
-  static constexpr int get_type() noexcept
-  {
-    return 0;
-  }
+  template <int index> static constexpr int get_type() noexcept { return 0; }
 };

--- a/tyndall/proto/binlog.h
+++ b/tyndall/proto/binlog.h
@@ -1,65 +1,51 @@
-#include <google/protobuf/util/delimited_message_util.h>
-#include <fcntl.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <google/protobuf/util/delimited_message_util.h>
 
 #include "tyndall/meta/strval.h"
 
-int binlog_create(const char* path)
-{
+int binlog_create(const char *path) {
   return open(path, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
 }
 
-template<typename ProtoMessage>
-requires(std::is_base_of<::google::protobuf::Message, ProtoMessage>::value)
-int binlog_write(int fd, const ProtoMessage& proto)
-{
-  if (fd == -1)
-  {
+template <typename ProtoMessage>
+  requires(std::is_base_of<::google::protobuf::Message, ProtoMessage>::value)
+int binlog_write(int fd, const ProtoMessage &proto) {
+  if (fd == -1) {
     errno = ENOENT;
     return -1;
-  }
-  else
-  {
+  } else {
     if (::google::protobuf::util::SerializeDelimitedToFileDescriptor(proto, fd))
       return 0;
-    else
-    {
+    else {
       errno = EPROTO;
       return -1;
     }
   }
 }
 
-int binlog_open(const char* path)
-{
-  return open(path, O_RDONLY);
-}
+int binlog_open(const char *path) { return open(path, O_RDONLY); }
 
-template<typename ProtoMessage>
-requires(std::is_base_of<::google::protobuf::Message, ProtoMessage>::value)
-int binlog_read(int fd, ProtoMessage& proto)
-{
-  if (fd == -1)
-  {
+template <typename ProtoMessage>
+  requires(std::is_base_of<::google::protobuf::Message, ProtoMessage>::value)
+int binlog_read(int fd, ProtoMessage &proto) {
+  if (fd == -1) {
     errno = ENOENT;
     return -1;
-  }
-  else
-  {
-    static ::google::protobuf::io::FileInputStream* stream = NULL;
+  } else {
+    static ::google::protobuf::io::FileInputStream *stream = NULL;
     static int fd_save = -1;
-    if (fd != fd_save)
-    {
+    if (fd != fd_save) {
       fd_save = fd;
       delete stream;
       stream = new ::google::protobuf::io::FileInputStream(fd);
     }
 
     bool clean_eof;
-    if (::google::protobuf::util::ParseDelimitedFromZeroCopyStream(&proto, stream, &clean_eof))
+    if (::google::protobuf::util::ParseDelimitedFromZeroCopyStream(
+            &proto, stream, &clean_eof))
       return 0;
-    else
-    {
+    else {
       delete stream;
 
       if (clean_eof)

--- a/tyndall/reflect/n_fields.h
+++ b/tyndall/reflect/n_fields.h
@@ -1,95 +1,90 @@
 #pragma once
-#include <type_traits>
-#include <utility>
-#include <climits>
-#include <typeinfo>
-#include <cstdio>
 #include "tyndall/meta/typeinfo.h"
+#include <climits>
+#include <cstdio>
+#include <type_traits>
+#include <typeinfo>
+#include <utility>
 
-// based on https://github.com/apolukhin/pfr_non_boost/blob/91f801bb08cf817c640d9c6d57ddfad5f38de92d/include/pfr/detail/fields_count.hpp
-// , with license: https://github.com/apolukhin/pfr_non_boost/blob/91f801bb08cf817c640d9c6d57ddfad5f38de92d/LICENSE_1_0.txt
+// based on
+// https://github.com/apolukhin/pfr_non_boost/blob/91f801bb08cf817c640d9c6d57ddfad5f38de92d/include/pfr/detail/fields_count.hpp
+// , with license:
+// https://github.com/apolukhin/pfr_non_boost/blob/91f801bb08cf817c640d9c6d57ddfad5f38de92d/LICENSE_1_0.txt
 
-namespace n_fields_detail
-{
-  template<size_t... I>
-  using index_sequence = std::integer_sequence<size_t, I...>;
+namespace n_fields_detail {
+template <size_t... I>
+using index_sequence = std::integer_sequence<size_t, I...>;
 
-  template<size_t N>
-  using make_index_sequence = std::make_integer_sequence<size_t, N>;
+template <size_t N>
+using make_index_sequence = std::make_integer_sequence<size_t, N>;
 
-  template <typename T>
-  constexpr T unsafe_declval() noexcept {
-    constexpr typename std::remove_reference_t<T>* ptr = 0;
-    return static_cast<T>(*ptr);
-  }
-
-  struct ubiq_lref_constructor {
-    int ignore;
-    template <typename T> constexpr operator T&() const && noexcept {
-      return unsafe_declval<T&>();
-    }
-
-    template <typename T> constexpr operator T&() const & noexcept {
-      return unsafe_declval<T&>();
-    }
-  };
-
-  struct ubiq_rref_constructor {
-    int ignore;
-    template <typename T> constexpr operator T() const && noexcept {
-      return unsafe_declval<T>();
-    }
-  };
-
-  template<typename T, size_t... I>
-  requires(std::is_copy_constructible_v<T>)
-  constexpr auto constructible(index_sequence<I...>) noexcept
-    -> typename std::add_pointer_t<decltype(T{ ubiq_lref_constructor{I}... })>;
-
-  template<typename T, size_t... I>
-  requires(!std::is_copy_constructible_v<T>)
-  constexpr auto constructible(index_sequence<I...>) noexcept
-    -> typename std::add_pointer_t<decltype(T{ ubiq_rref_constructor{I}... })>;
-
-  template <class T, size_t N, typename = decltype(constructible<T>(make_index_sequence<N>()))>
-  using constructible_t = size_t;
-
-  template<typename T, size_t N>
-  constexpr auto n_fields_linear(long) noexcept -> constructible_t<T, N>
-  {
-    return N;
-  }
-
-  template<typename T, size_t N>
-  constexpr size_t n_fields_linear(int) noexcept
-  {
-    return n_fields_linear<T, N-1>(0l);
-  }
-
-  template<typename T, size_t N>
-  constexpr auto n_fields_binary(long) noexcept -> constructible_t<T, N>
-  {
-    return N;
-  }
-
-  template<typename T, size_t N>
-  constexpr size_t n_fields_binary(int) noexcept
-  {
-    return n_fields_binary<T, N/2>(0l);
-  }
+template <typename T> constexpr T unsafe_declval() noexcept {
+  constexpr typename std::remove_reference_t<T> *ptr = 0;
+  return static_cast<T>(*ptr);
 }
 
-template<typename T>
-constexpr size_t n_fields() noexcept
-{
-  constexpr size_t max_field_count = sizeof(T)*CHAR_BIT;
+struct ubiq_lref_constructor {
+  int ignore;
+  template <typename T> constexpr operator T &() const && noexcept {
+    return unsafe_declval<T &>();
+  }
+
+  template <typename T> constexpr operator T &() const & noexcept {
+    return unsafe_declval<T &>();
+  }
+};
+
+struct ubiq_rref_constructor {
+  int ignore;
+  template <typename T> constexpr operator T() const && noexcept {
+    return unsafe_declval<T>();
+  }
+};
+
+template <typename T, size_t... I>
+  requires(std::is_copy_constructible_v<T>)
+constexpr auto constructible(index_sequence<I...>) noexcept ->
+    typename std::add_pointer_t<decltype(T{ubiq_lref_constructor{I}...})>;
+
+template <typename T, size_t... I>
+  requires(!std::is_copy_constructible_v<T>)
+constexpr auto constructible(index_sequence<I...>) noexcept ->
+    typename std::add_pointer_t<decltype(T{ubiq_rref_constructor{I}...})>;
+
+template <class T, size_t N,
+          typename = decltype(constructible<T>(make_index_sequence<N>()))>
+using constructible_t = size_t;
+
+template <typename T, size_t N>
+constexpr auto n_fields_linear(long) noexcept -> constructible_t<T, N> {
+  return N;
+}
+
+template <typename T, size_t N> constexpr size_t n_fields_linear(int) noexcept {
+  return n_fields_linear<T, N - 1>(0l);
+}
+
+template <typename T, size_t N>
+constexpr auto n_fields_binary(long) noexcept -> constructible_t<T, N> {
+  return N;
+}
+
+template <typename T, size_t N> constexpr size_t n_fields_binary(int) noexcept {
+  return n_fields_binary<T, N / 2>(0l);
+}
+} // namespace n_fields_detail
+
+template <typename T> constexpr size_t n_fields() noexcept {
+  constexpr size_t max_field_count = sizeof(T) * CHAR_BIT;
 
   using type = std::remove_cvref_t<T>;
 
-  static_assert(std::is_aggregate<type>::value || std::is_scalar<type>::value, "T must be aggregate initializable");
+  static_assert(std::is_aggregate<type>::value || std::is_scalar<type>::value,
+                "T must be aggregate initializable");
 
   // Binary search is applied to avoid too large template depth.
-  constexpr size_t binary_search = n_fields_detail::n_fields_binary<type, max_field_count>(0l);
+  constexpr size_t binary_search =
+      n_fields_detail::n_fields_binary<type, max_field_count>(0l);
 
   return n_fields_detail::n_fields_linear<type, binary_search * 2 + 1>(0l);
 }

--- a/tyndall/reflect/print_format.h
+++ b/tyndall/reflect/print_format.h
@@ -1,220 +1,173 @@
 #pragma once
-#include <tyndall/meta/strval.h>
 #include <cstddef>
-#include <cstdio>
 #include <cstdint>
+#include <cstdio>
+#include <tyndall/meta/strval.h>
 
-// print_format_typeid returns the typeid character for basic types and empty otherwise
-template<typename T>
-constexpr auto print_format_typeid() noexcept
-{
+// print_format_typeid returns the typeid character for basic types and empty
+// otherwise
+template <typename T> constexpr auto print_format_typeid() noexcept {
   return ""_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<bool>() noexcept
-{
+template <> constexpr auto print_format_typeid<bool>() noexcept {
   return "b"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<float>() noexcept
-{
+template <> constexpr auto print_format_typeid<float>() noexcept {
   return "f"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<double>() noexcept
-{
+template <> constexpr auto print_format_typeid<double>() noexcept {
   return "d"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<int>() noexcept
-{
+template <> constexpr auto print_format_typeid<int>() noexcept {
   return "i"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<unsigned int>() noexcept
-{
+template <> constexpr auto print_format_typeid<unsigned int>() noexcept {
   return "j"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<short>() noexcept
-{
+template <> constexpr auto print_format_typeid<short>() noexcept {
   return "s"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<unsigned short>() noexcept
-{
+template <> constexpr auto print_format_typeid<unsigned short>() noexcept {
   return "t"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<char>() noexcept
-{
+template <> constexpr auto print_format_typeid<char>() noexcept {
   return "c"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<unsigned char>() noexcept
-{
+template <> constexpr auto print_format_typeid<unsigned char>() noexcept {
   return "h"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<long>() noexcept
-{
+template <> constexpr auto print_format_typeid<long>() noexcept {
   return "l"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<unsigned long>() noexcept
-{
+template <> constexpr auto print_format_typeid<unsigned long>() noexcept {
   return "m"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<long long>() noexcept
-{
+template <> constexpr auto print_format_typeid<long long>() noexcept {
   return "x"_strval;
 }
 
-template<>
-constexpr auto print_format_typeid<unsigned long long>() noexcept
-{
+template <> constexpr auto print_format_typeid<unsigned long long>() noexcept {
   return "y"_strval;
 }
 
 // TODO:
-//template<>
-//constexpr auto print_format_get<const char*>() noexcept
+// template<>
+// constexpr auto print_format_get<const char*>() noexcept
 //{
 //  return "s"_strval;
 //}
 
-// print_format_printf returns the printf format for basic types and empty otherwise
-template<typename T>
-constexpr auto print_format_printf() noexcept
-{
+// print_format_printf returns the printf format for basic types and empty
+// otherwise
+template <typename T> constexpr auto print_format_printf() noexcept {
   return ""_strval;
 }
 
-template<>
-constexpr auto print_format_printf<bool>() noexcept
-{
+template <> constexpr auto print_format_printf<bool>() noexcept {
   return "%d"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<float>() noexcept
-{
+template <> constexpr auto print_format_printf<float>() noexcept {
   return "%f"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<double>() noexcept
-{
+template <> constexpr auto print_format_printf<double>() noexcept {
   return "%f"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<int>() noexcept
-{
+template <> constexpr auto print_format_printf<int>() noexcept {
   return "%d"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<unsigned int>() noexcept
-{
+template <> constexpr auto print_format_printf<unsigned int>() noexcept {
   return "%u"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<short>() noexcept
-{
+template <> constexpr auto print_format_printf<short>() noexcept {
   return "%d"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<unsigned short>() noexcept
-{
+template <> constexpr auto print_format_printf<unsigned short>() noexcept {
   return "%u"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<char>() noexcept
-{
+template <> constexpr auto print_format_printf<char>() noexcept {
   return "%c"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<unsigned char>() noexcept
-{
+template <> constexpr auto print_format_printf<unsigned char>() noexcept {
   return "%u"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<long>() noexcept
-{
+template <> constexpr auto print_format_printf<long>() noexcept {
   return "%ld"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<unsigned long>() noexcept
-{
+template <> constexpr auto print_format_printf<unsigned long>() noexcept {
   return "%u"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<long long>() noexcept
-{
+template <> constexpr auto print_format_printf<long long>() noexcept {
   return "%lld"_strval;
 }
 
-template<>
-constexpr auto print_format_printf<unsigned long long>() noexcept
-{
+template <> constexpr auto print_format_printf<unsigned long long>() noexcept {
   return "%llu"_strval;
 }
 
-
-template<typename T>
-size_t print_format_alignment(const char* ptr)
-{
+template <typename T> size_t print_format_alignment(const char *ptr) {
   size_t alignment_error = reinterpret_cast<const uintptr_t>(ptr) % sizeof(T);
   return (alignment_error > 0) ? sizeof(T) - alignment_error : 0;
 }
 
-template<typename Fmt>
-size_t print_format(const char* data)
-{
+template <typename Fmt> size_t print_format(const char *data) {
   const size_t align = print_format_alignment<Fmt>(data);
-  printf((print_format_printf<Fmt>() + print_format_typeid<Fmt>()).c_str(), *(Fmt*)(data + align));
+  printf((print_format_printf<Fmt>() + print_format_typeid<Fmt>()).c_str(),
+         *(Fmt *)(data + align));
   return sizeof(Fmt) + align;
 }
 
-static inline size_t print_format(char c, const char* data)
-{
-  switch(c)
-  {
-    case print_format_typeid<bool>().get<0>():          return print_format<bool>(data);
-    case print_format_typeid<float>().get<0>():         return print_format<float>(data);
-    case print_format_typeid<double>().get<0>():        return print_format<double>(data);
-    case print_format_typeid<int>().get<0>():           return print_format<int>(data);
-    case print_format_typeid<unsigned int>().get<0>():  return print_format<unsigned int>(data);
-    case print_format_typeid<short>().get<0>():         return print_format<short>(data);
-    case print_format_typeid<unsigned short>().get<0>():  return print_format<unsigned short>(data);
-    case print_format_typeid<char>().get<0>():          return print_format<char>(data);
-    case print_format_typeid<unsigned char>().get<0>(): return print_format<unsigned char>(data);
-    case print_format_typeid<long>().get<0>():          return print_format<long>(data);
-    case print_format_typeid<unsigned long>().get<0>(): return print_format<unsigned long>(data);
-    case print_format_typeid<long long>().get<0>():     return print_format<long long>(data);
-    case print_format_typeid<unsigned long long>().get<0>():  return print_format<unsigned long long>(data);
-    default:
-      return 0;
+static inline size_t print_format(char c, const char *data) {
+  switch (c) {
+  case print_format_typeid<bool>().get<0>():
+    return print_format<bool>(data);
+  case print_format_typeid<float>().get<0>():
+    return print_format<float>(data);
+  case print_format_typeid<double>().get<0>():
+    return print_format<double>(data);
+  case print_format_typeid<int>().get<0>():
+    return print_format<int>(data);
+  case print_format_typeid<unsigned int>().get<0>():
+    return print_format<unsigned int>(data);
+  case print_format_typeid<short>().get<0>():
+    return print_format<short>(data);
+  case print_format_typeid<unsigned short>().get<0>():
+    return print_format<unsigned short>(data);
+  case print_format_typeid<char>().get<0>():
+    return print_format<char>(data);
+  case print_format_typeid<unsigned char>().get<0>():
+    return print_format<unsigned char>(data);
+  case print_format_typeid<long>().get<0>():
+    return print_format<long>(data);
+  case print_format_typeid<unsigned long>().get<0>():
+    return print_format<unsigned long>(data);
+  case print_format_typeid<long long>().get<0>():
+    return print_format<long long>(data);
+  case print_format_typeid<unsigned long long>().get<0>():
+    return print_format<unsigned long long>(data);
+  default:
+    return 0;
   }
 }

--- a/tyndall/reflect/reflect.h
+++ b/tyndall/reflect/reflect.h
@@ -1,112 +1,108 @@
 #pragma once
-#include <type_traits>
+#include "n_fields.h"
+#include "reflection.h"
+#include "tyndall/meta/typeinfo.h"
 #include <cstddef>
 #include <tyndall/meta/macro.h>
 #include <tyndall/meta/static_warn.h>
-#include "reflection.h"
-#include "n_fields.h"
-#include "tyndall/meta/typeinfo.h"
+#include <type_traits>
 
-// based on https://github.com/apolukhin/pfr_non_boost/blob/91f801bb08cf817c640d9c6d57ddfad5f38de92d/include/pfr/detail/core17_generated.hpp
-// , with license: https://github.com/apolukhin/pfr_non_boost/blob/91f801bb08cf817c640d9c6d57ddfad5f38de92d/LICENSE_1_0.txt
+// based on
+// https://github.com/apolukhin/pfr_non_boost/blob/91f801bb08cf817c640d9c6d57ddfad5f38de92d/include/pfr/detail/core17_generated.hpp
+// , with license:
+// https://github.com/apolukhin/pfr_non_boost/blob/91f801bb08cf817c640d9c6d57ddfad5f38de92d/LICENSE_1_0.txt
 
 #ifndef REFLECT_MAX_FIELDS
 #define REFLECT_MAX_FIELDS 30
 #endif
-static_assert(M_INC(REFLECT_MAX_FIELDS) < M_MAX_ARITHMETIC, "REFLECT_MAX_FIELDS must be less than M_MAX_ARITHMETIC, specified in <tyndall/meta/macro.h>");
+static_assert(M_INC(REFLECT_MAX_FIELDS) < M_MAX_ARITHMETIC,
+              "REFLECT_MAX_FIELDS must be less than M_MAX_ARITHMETIC, "
+              "specified in <tyndall/meta/macro.h>");
 
-template<size_t I>
-using size_t_ = std::integral_constant<size_t, I>;
+template <size_t I> using size_t_ = std::integral_constant<size_t, I>;
 
-template<typename T>
-constexpr auto reflect_impl(T&& t, size_t_<0>) noexcept
-{
+template <typename T> constexpr auto reflect_impl(T &&t, size_t_<0>) noexcept {
   return reflection<>{};
 }
 
 #define REFLECT_BINDING(I, _) M_CAT(a, I)
 #define REFLECT_DECLTYPE_BINDING(I, _) decltype(M_CAT(a, I))
-#define REFLECT_FORWARD_DECLTYPE_BINDING(I, _) std::forward<decltype(M_CAT(a, I))>(M_CAT(a, I))
+#define REFLECT_FORWARD_DECLTYPE_BINDING(I, _)                                 \
+  std::forward<decltype(M_CAT(a, I))>(M_CAT(a, I))
 
-#define REFLECT_I(I, _) \
-template<typename T> \
-constexpr auto reflect_impl(T&& t, size_t_<I>) noexcept \
-{ \
-  auto&& [ M_RANGE_WITH_COMMA(REFLECT_BINDING, 0, I) ] = t; \
-  return reflection<M_RANGE_WITH_COMMA(REFLECT_DECLTYPE_BINDING, 0, I)>{M_RANGE_WITH_COMMA(REFLECT_FORWARD_DECLTYPE_BINDING, 0,I)}; \
-}
+#define REFLECT_I(I, _)                                                        \
+  template <typename T>                                                        \
+  constexpr auto reflect_impl(T &&t, size_t_<I>) noexcept {                    \
+    auto &&[M_RANGE_WITH_COMMA(REFLECT_BINDING, 0, I)] = t;                    \
+    return reflection<M_RANGE_WITH_COMMA(REFLECT_DECLTYPE_BINDING, 0, I)>{     \
+        M_RANGE_WITH_COMMA(REFLECT_FORWARD_DECLTYPE_BINDING, 0, I)};           \
+  }
 M_EVAL(M_RANGE(REFLECT_I, 1, M_INC(REFLECT_MAX_FIELDS)))
 
 // The range above produces items like the following (for I=3):
-//template<typename T>
-//constexpr auto reflect_impl(T&& t, size_t_<3>) noexcept
+// template<typename T>
+// constexpr auto reflect_impl(T&& t, size_t_<3>) noexcept
 //{
 //  auto&& [a0, a1, a2] = t;
-//  return reflection<decltype(a0), decltype(a1), decltype(a2)>{std::forward<decltype(a0)>(a0), std::forward<decltype(a1)>(a1), std::forward<decltype(a2)>(a2)};
+//  return reflection<decltype(a0), decltype(a1),
+//  decltype(a2)>{std::forward<decltype(a0)>(a0),
+//  std::forward<decltype(a1)>(a1), std::forward<decltype(a2)>(a2)};
 //}
 
-template<typename T, size_t I>
-constexpr reflection<> reflect_impl(T&&, size_t_<I>) noexcept
-{
-  static_assert(sizeof(T) && false, "number of fields cannot exceed REFLECT_MAX_FIELDS");
+template <typename T, size_t I>
+constexpr reflection<> reflect_impl(T &&, size_t_<I>) noexcept {
+  static_assert(sizeof(T) && false,
+                "number of fields cannot exceed REFLECT_MAX_FIELDS");
   return {};
 }
 
-template<typename T>
-requires(!std::is_class_v<std::remove_cvref_t<T>>)
-constexpr auto reflect_scalar(T&& t) noexcept
-{
+template <typename T>
+  requires(!std::is_class_v<std::remove_cvref_t<T>>)
+constexpr auto reflect_scalar(T &&t) noexcept {
   static_assert(std::is_scalar_v<std::remove_cvref_t<T>>, "T must be scalar");
   return reflection<decltype(t)>{std::forward<T>(t)};
 }
 
-template<typename T>
-requires(std::is_class_v<std::remove_cvref_t<T>>)
-constexpr auto reflect_scalar(T&& t) noexcept
-{
-  auto&& [a0] = t;
+template <typename T>
+  requires(std::is_class_v<std::remove_cvref_t<T>>)
+constexpr auto reflect_scalar(T &&t) noexcept {
+  auto &&[a0] = t;
   return reflection<decltype(a0)>{std::forward<decltype(a0)>(a0)};
 }
 
-
-template<typename T>
-constexpr auto reflect_aggregate(T&& t) noexcept
-{
+template <typename T> constexpr auto reflect_aggregate(T &&t) noexcept {
   using type = const std::remove_cvref_t<T>;
 
   static_assert(!std::is_union_v<type>, "unions are not supported");
 
   constexpr size_t number_of_fields = n_fields<type>();
-  static_assert(number_of_fields <= REFLECT_MAX_FIELDS, "Struct too large! Maybe increase REFLECT_MAX_FIELDS");
+  static_assert(number_of_fields <= REFLECT_MAX_FIELDS,
+                "Struct too large! Maybe increase REFLECT_MAX_FIELDS");
   return reflect_impl<type>(std::forward<type>(t), size_t_<number_of_fields>{});
 }
 
-template<typename T>
-constexpr auto reflect_aggregate() noexcept
-{
-  static_assert(std::is_aggregate_v<std::remove_cvref_t<T>>, "T must be aggregate");
+template <typename T> constexpr auto reflect_aggregate() noexcept {
+  static_assert(std::is_aggregate_v<std::remove_cvref_t<T>>,
+                "T must be aggregate");
 
   return reflect_aggregate(T{});
 }
 
-template<typename T>
-constexpr auto reflect(T&& t) noexcept
-{
-  if constexpr(n_fields<T>() == 1)
+template <typename T> constexpr auto reflect(T &&t) noexcept {
+  if constexpr (n_fields<T>() == 1)
     return reflect_scalar<T>(std::forward<T>(t));
   else
     return reflect_aggregate(std::forward<T>(t));
 }
 
-template<typename T>
-constexpr auto reflect() noexcept
-{
+template <typename T> constexpr auto reflect() noexcept {
   using type = std::remove_cvref_t<T>;
 
-  constexpr bool aggregate_initializable = std::is_aggregate_v<type> || std::is_scalar_v<type>;
+  constexpr bool aggregate_initializable =
+      std::is_aggregate_v<type> || std::is_scalar_v<type>;
   static_warn(aggregate_initializable, "T must be aggregate initializable");
 
-  if constexpr(aggregate_initializable)
+  if constexpr (aggregate_initializable)
     return reflect(T{});
   else
     return reflection<>{};

--- a/tyndall/reflect/reflection.h
+++ b/tyndall/reflect/reflection.h
@@ -2,80 +2,61 @@
 #include <type_traits>
 #include <utility>
 
+#include "print_format.h"
 #include "tyndall/meta/strval.h"
 #include "tyndall/meta/typeinfo.h"
-#include "print_format.h"
 
-template<typename T>
-constexpr auto reflect_aggregate() noexcept;
+template <typename T> constexpr auto reflect_aggregate() noexcept;
 
-template<typename... Args>
-struct reflection
-{};
+template <typename... Args> struct reflection {};
 
-template<typename Lhs, typename... Rhs>
-struct reflection<Lhs, Rhs...> : public reflection<Rhs...>
-{
-  const Lhs& lhs;
+template <typename Lhs, typename... Rhs>
+struct reflection<Lhs, Rhs...> : public reflection<Rhs...> {
+  const Lhs &lhs;
 
-  explicit constexpr reflection(Lhs&& lhs, Rhs&&... rhs) noexcept
-  : reflection<Rhs...>{std::forward<Rhs>(rhs)...}
-  , lhs(lhs)
-  {}
+  explicit constexpr reflection(Lhs &&lhs, Rhs &&...rhs) noexcept
+      : reflection<Rhs...>{std::forward<Rhs>(rhs)...}, lhs(lhs) {}
 
-  template<size_t index>
-  constexpr const auto& get() const noexcept
-  {
+  template <size_t index> constexpr const auto &get() const noexcept {
     return get_impl<index>(*this);
   }
 
-  static constexpr size_t size() noexcept
-  {
-    return 1 + sizeof...(Rhs);
-  }
+  static constexpr size_t size() noexcept { return 1 + sizeof...(Rhs); }
 
-  static constexpr auto get_format() noexcept
-  {
-    constexpr auto lhs_format = ::print_format_typeid<std::remove_cvref_t<Lhs>>();
+  static constexpr auto get_format() noexcept {
+    constexpr auto lhs_format =
+        ::print_format_typeid<std::remove_cvref_t<Lhs>>();
 
     constexpr auto rhs_format = reflection<Rhs...>::get_format();
 
-    if constexpr(lhs_format == ""_strval)
+    if constexpr (lhs_format == ""_strval)
       return reflect_aggregate<Lhs>().get_format() + rhs_format;
     else
       return lhs_format + rhs_format;
   }
 
 protected:
-
-  template<size_t index>
-  requires(index == 0)
-  static constexpr const Lhs& get_impl(const reflection<Lhs, Rhs...>& refl) noexcept
-  {
+  template <size_t index>
+    requires(index == 0)
+  static constexpr const Lhs &
+  get_impl(const reflection<Lhs, Rhs...> &refl) noexcept {
     return refl.lhs;
   }
 
-  template<size_t index>
-  requires(index > 0)
-  static constexpr const auto& get_impl(const reflection<Lhs, Rhs...>& refl) noexcept
-  {
-    return reflection<Rhs...>::template get_impl<index-1>(static_cast<const reflection<Rhs...>&>(refl));
+  template <size_t index>
+    requires(index > 0)
+  static constexpr const auto &
+  get_impl(const reflection<Lhs, Rhs...> &refl) noexcept {
+    return reflection<Rhs...>::template get_impl<index - 1>(
+        static_cast<const reflection<Rhs...> &>(refl));
   }
 };
 
-template<>
-struct reflection<>
-{
+template <> struct reflection<> {
 public:
-  static constexpr size_t size() noexcept
-  {
-    return 0;
-  }
+  static constexpr size_t size() noexcept { return 0; }
 
-  static constexpr auto get_format() noexcept
-  {
-    return ""_strval;
-  }
+  static constexpr auto get_format() noexcept { return ""_strval; }
 };
 
 #include "reflect.h"


### PR DESCRIPTION
When using `ipc_read(entry, "/whatever")` if the entry hasn't been updated and we assume that the caller keeps the previous value in memory (by making it static or keeping it as a class member), there is no need to copy the entry again.

This PR also takes the chance to run clang-format on the code to bring it into similar style to the rest of the blunux projects.