### PR TITLE
Add more checks around lazy publisher creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /build_imx
 .DS_Store
 .vscode
+build_*


### PR DESCRIPTION
Might be related to https://github.com/BluEye-Robotics/p2_drone/issues/759.

In any case proper checking of the node handle is recommended.