### PR TITLE
Implement move semantics for context_t and socket_t classes

### DIFF
--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -1,0 +1,24 @@
+name: compile_macos
+
+on: [push]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-14
+
+    steps:
+      - name: Install Packages
+        run: |
+          brew install boost fmt jq zeromq googletest
+
+      # tyndall
+      - uses: actions/checkout@v2
+        with:
+          path: tyndall
+          lfs: true
+      - name: Build
+        run: cd $GITHUB_WORKSPACE/tyndall && mkdir build && cd build && cmake .. && make all

--- a/tests/proto/zmq_proto.cpp
+++ b/tests/proto/zmq_proto.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <google/protobuf/wrappers.pb.h>
+#include <iostream>
 #include <thread>
 #include <tyndall/meta/macro.h>
 #include <tyndall/proto/zmq_proto.h>
@@ -16,8 +17,23 @@
 
 int main() {
   zmq_proto::context_t context{1};
-  zmq_proto::socket_t<zmq_proto::PUB> pub(context, "tcp://*:5444");
-  zmq_proto::socket_t<zmq_proto::SUB> sub(context, "tcp://127.0.0.1:5444");
+  zmq_proto::socket_t<zmq_proto::PUB> pub_1(context, "tcp://*:5444");
+  zmq_proto::socket_t<zmq_proto::SUB> sub_1(context, "tcp://127.0.0.1:5444");
+
+  auto handle_pub = pub_1.zmq_handle();
+  auto handle_sub = sub_1.zmq_handle();
+
+  check(handle_pub != NULL);
+  check(handle_sub != NULL);
+
+  zmq_proto::socket_t<zmq_proto::PUB> pub = std::move(pub_1);
+  zmq_proto::socket_t<zmq_proto::SUB> sub = std::move(sub_1);
+
+  check(handle_pub == pub.zmq_handle());
+  check(handle_sub == sub.zmq_handle());
+
+  check(pub_1.zmq_handle() == NULL);
+  check(sub_1.zmq_handle() == NULL);
 
   std::thread sub_thread([&sub]() {
     google::protobuf::Int32Value msg;

--- a/tests/proto/zmq_proto.cpp
+++ b/tests/proto/zmq_proto.cpp
@@ -1,6 +1,5 @@
 #include <assert.h>
 #include <google/protobuf/wrappers.pb.h>
-#include <iostream>
 #include <thread>
 #include <tyndall/meta/macro.h>
 #include <tyndall/proto/zmq_proto.h>

--- a/tyndall/proto/zmq_proto.h
+++ b/tyndall/proto/zmq_proto.h
@@ -39,6 +39,19 @@ public:
     zmq_proto_assert(rc == 0);
   }
 
+  // Implement move constructor
+  context_t(context_t &&other) noexcept : context(other.context) {
+    other.context = NULL; // Set the moved-from context to NULL
+  }
+
+  context_t &operator=(context_t &&other) noexcept {
+    if (this != &other && other.context != NULL) {
+      context = other.context;
+      other.context = NULL; // Set the moved-from context to NULL
+    }
+    return *this;
+  }
+
   int init(int n_threads) {
     context = zmq_ctx_new();
     zmq_proto_assert(context != NULL);
@@ -56,6 +69,12 @@ public:
   void *zmq_handle() { return context; }
 
   ~context_t() {
+    // Avoid double close
+    if (context == NULL) {
+      return;
+    }
+    printf("[ %s:%d %s ] Closing context %p\n", __FILE__, __LINE__, __func__,
+           context);
     int rc;
     do {
       rc = zmq_ctx_destroy(context);
@@ -119,11 +138,29 @@ public:
     }
   }
 
+  // Implement move constructor and assignment operator
+  socket_t(socket_t &&other) noexcept : socket(other.socket) {
+    other.socket = NULL; // Set the moved-from socket to NULL
+  }
+  socket_t &operator=(socket_t &&other) noexcept {
+    if (this != &other && other.socket != NULL) {
+      socket = other.socket;
+      other.socket = NULL; // Set the moved-from socket to NULL
+    }
+    return *this;
+  }
+
   void *zmq_handle() const { return socket; }
 
   void *zmq_handle() { return socket; }
 
   ~socket_t() {
+    // Avoid double close
+    if (socket == NULL) {
+      return;
+    }
+    printf("[ %s:%d %s ] Closing socket %p\n", __FILE__, __LINE__, __func__,
+           socket);
     int rc = zmq_close(socket);
     zmq_proto_assert(rc == 0);
 
@@ -152,6 +189,12 @@ public:
     int rc = zmq_msg_close(&msg);
     zmq_proto_assert(rc == 0);
   }
+
+  // Disallow copy constructor, assignment operator and move operations
+  msg_t(const msg_t &) = delete;
+  msg_t &operator=(const msg_t &) = delete;
+  msg_t(msg_t &&) = delete;
+  msg_t &operator=(msg_t &&) = delete;
 };
 
 // helpers:
@@ -324,10 +367,10 @@ int recv_more(::google::protobuf::MessageLite &proto_msg,
 
 /*
   receives two parts of a multipart message. Matches first with type name and
-  parses second into proto errno: EAGAIN if the inbound message queue was empty
-  errno: EBADMSG if the type name didn't match
-  errno: EOPNOTSUPP if there were no more message parts to receive after first
-  part errno: EPROTO if the proto could not be parsed / did not match
+  parses second into proto errno: EAGAIN if the inbound message queue was
+  empty errno: EBADMSG if the type name didn't match errno: EOPNOTSUPP if
+  there were no more message parts to receive after first part errno: EPROTO
+  if the proto could not be parsed / did not match
 */
 template <socket_type_t socket_type>
 int recv(::google::protobuf::MessageLite &proto_msg,


### PR DESCRIPTION
Currently, copying or moving context_t, socket_t, and msg_t could result in double deallocations. This PR makes them safer to use. 


### Enhancements to resource management:

* **Move semantics for `context_t`**: Added move constructor and assignment operator to efficiently transfer ownership of the ZeroMQ context, ensuring the moved-from object avoids double closures.
* **Move semantics for `socket_t`**: Implemented move constructor and assignment operator for the `socket_t` class, ensuring the moved-from object avoids double closures.

### Robustness improvements:

* **Disallow copy and move operations for `msg_t`**: Explicitly deleted copy constructor, copy assignment operator, move constructor, and move assignment operator for `msg_t` to ensure proper handling of message resources.

### Minor updates:

* **Expanded test coverage**: Modified `tests/proto/zmq_proto.cpp` to include tests for move semantics and resource management, verifying that handles are correctly transferred and invalidated.
* **Documentation improvements**: Updated comments in `tyndall/proto/zmq_proto.h` to clarify error codes and behavior in the `recv_more` function.