### PR TITLE
Fix ipc_read tool offsets on 64-bit targets

### DIFF
--- a/tools/ipc_read.cpp
+++ b/tools/ipc_read.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <cstddef>
 #include <tyndall/ipc/seq_lock.h>
 #include <tyndall/reflect/print_format.h>
 #include <unistd.h>
@@ -162,15 +163,24 @@ int main(int argc, char **argv) {
   // shared memory should be page aligned:
   assert(reinterpret_cast<uintptr_t>(mapped) % CACHELINE_BYTES == 0);
 
+  // The shared memory layout is defined by seq_lock<STORAGE>. The offsets of
+  // seq, size, and entry depend on the platform's alignment rules (e.g. on
+  // 64-bit targets size_t introduces padding between seq and size), so compute
+  // them with offsetof instead of assuming the entry starts at CACHELINE_BYTES.
+  using probe_lock = seq_lock<char>;
+
   // Seq lock number address
-  unsigned *ipc_seq = (unsigned *)mapped;
+  unsigned *ipc_seq =
+      (unsigned *)((char *)mapped + offsetof(probe_lock, seq));
 
   // Data size address
-  size_t *data_size = (size_t *)(mapped + sizeof(unsigned));
+  size_t *data_size =
+      (size_t *)((char *)mapped + offsetof(probe_lock, size));
   // Data address
-  const char *const ipc_buf = (const char *)mapped + CACHELINE_BYTES;
+  const char *const ipc_buf =
+      (const char *)mapped + offsetof(probe_lock, entry);
 
-  const size_t buf_size = ipc_size - 2 * sizeof(int) - CACHELINE_BYTES;
+  const size_t buf_size = ipc_size - offsetof(probe_lock, entry);
 
   std::vector<char> buffer(buf_size + CACHELINE_BYTES, 0);
 

--- a/tools/ipc_read.cpp
+++ b/tools/ipc_read.cpp
@@ -164,10 +164,32 @@ int main(int argc, char **argv) {
   assert(reinterpret_cast<uintptr_t>(mapped) % CACHELINE_BYTES == 0);
 
   // The shared memory layout is defined by seq_lock<STORAGE>. The offsets of
-  // seq, size, and entry depend on the platform's alignment rules (e.g. on
-  // 64-bit targets size_t introduces padding between seq and size), so compute
-  // them with offsetof instead of assuming the entry starts at CACHELINE_BYTES.
+  // seq and size are fixed on a given platform (and computed with offsetof
+  // below), but the offset of entry depends on STORAGE's alignment: the
+  // compiler places entry right after padding[], rounded up to
+  // alignof(STORAGE). We don't know STORAGE here, but we can derive an upper
+  // bound on its alignment from the largest type in the format string.
   using probe_lock = seq_lock<char>;
+
+  auto format_char_align = [](char c) -> size_t {
+    switch (c) {
+    case 'd': // double
+    case 'l': // long
+    case 'm': // unsigned long
+    case 'x': // long long
+    case 'y': // unsigned long long
+      return 8;
+    case 'f': // float
+    case 'i': // int
+    case 'j': // unsigned int
+      return 4;
+    case 's': // short
+    case 't': // unsigned short
+      return 2;
+    default: // b(bool), c(char), h(unsigned char)
+      return 1;
+    }
+  };
 
   // Seq lock number address
   unsigned *ipc_seq =
@@ -176,11 +198,47 @@ int main(int argc, char **argv) {
   // Data size address
   size_t *data_size =
       (size_t *)((char *)mapped + offsetof(probe_lock, size));
-  // Data address
-  const char *const ipc_buf =
-      (const char *)mapped + offsetof(probe_lock, entry);
 
-  const size_t buf_size = ipc_size - offsetof(probe_lock, entry);
+  // Determine the format string up-front so we can compute the correct entry
+  // offset. If --format wasn't given, peek at the debug tailer at the end of
+  // the shmem region to recover it.
+  std::string fmt_string;
+  const std::vector<char> allowed = {'b', 'f', 'd', 'i', 'j', 's', 't',
+                                     'c', 'h', 'l', 'm', 'x', 'y'};
+  if (format.has_value()) {
+    fmt_string = format.get();
+  } else {
+    constexpr int type_info_hash_size = 4;
+    const size_t debug_tail_size = ipc_size - *data_size;
+    if (debug_tail_size > (size_t)type_info_hash_size) {
+      const size_t debug_format_size = debug_tail_size - type_info_hash_size;
+      char *const debug_format_loc = static_cast<char *>(mapped) + ipc_size -
+                                     debug_format_size + CACHELINE_BYTES + 24;
+      std::string candidate(debug_format_loc);
+      auto valid = !candidate.empty() &&
+                   std::all_of(candidate.begin(), candidate.end(), [&](char c) {
+                     return std::find(allowed.begin(), allowed.end(), c) !=
+                            allowed.end();
+                   });
+      if (valid)
+        fmt_string = candidate;
+    }
+  }
+
+  // Round entry offset up to STORAGE's alignment (upper-bounded by the
+  // strictest format char). If we have no format hint, fall back to 1-byte
+  // alignment, which only matches byte-aligned STORAGE types.
+  size_t storage_align = 1;
+  for (char c : fmt_string)
+    storage_align = std::max(storage_align, format_char_align(c));
+
+  const size_t entry_offset =
+      (offsetof(probe_lock, entry) + storage_align - 1) & ~(storage_align - 1);
+
+  // Data address
+  const char *const ipc_buf = (const char *)mapped + entry_offset;
+
+  const size_t buf_size = ipc_size - entry_offset;
 
   std::vector<char> buffer(buf_size + CACHELINE_BYTES, 0);
 
@@ -222,33 +280,13 @@ int main(int argc, char **argv) {
       continue;
     }
 
-    // extract debug format
-    constexpr int type_info_hash_size = 4;
-    const size_t debug_tail_size = ipc_size - *data_size;
-    const size_t debug_format_size = debug_tail_size - type_info_hash_size;
-
-    char *const debug_format_loc = static_cast<char *>(mapped) + ipc_size -
-                                   debug_format_size + CACHELINE_BYTES + 24;
-
-    char *fmt = debug_format_loc;
-    std::string fmt_string(fmt);
-
-    std::vector<char> allowed = {'b', 'f', 'd', 'i', 'j', 's', 't',
-                                 'c', 'h', 'l', 'm', 'x', 'y'};
-
-    auto valid = std::all_of(fmt_string.begin(), fmt_string.end(), [&](char c) {
-      return std::find(allowed.begin(), allowed.end(), c) != allowed.end();
-    });
-
-    if (debug_tail_size > type_info_hash_size && fmt_string.size() > 0 &&
-        valid) {
-      print(fmt, buf, buf_size);
+    if (!fmt_string.empty()) {
+      print(fmt_string.data(), buf, buf_size);
     } else {
       auto len = *data_size;
       for (size_t i = 0; i < len; ++i)
         printf("%02x", buf[i]);
       printf("\n");
-      // printf("int: %d\n", *(int*)buf);
     }
   } while (vm["continuous"].as<bool>());
 


### PR DESCRIPTION
Fixes the `tyndall_tool_ipc_read` data offsets so the tool works on Jetson (aarch64) and x86_64, not just i.MX (armv7).

## Problem

`tools/ipc_read.cpp` hardcoded the `seq_lock` layout, assuming the data buffer starts at `CACHELINE_BYTES` from the mapping base and that the `size_t size` field sits at offset `sizeof(unsigned) == 4`.

That only holds on 32-bit ARM (i.MX), where `sizeof(size_t) == 4` and the header packs into exactly one 32-byte cacheline. On 64-bit targets `size_t` is 8 bytes, so the compiler inserts 4 bytes of padding between `seq` and `size`, shifting the real `entry` offset:

| Platform | sizeof(size_t) | CACHELINE_BYTES | real `offsetof(entry)` | tool assumed |
|---|---|---|---|---|
| armv7 (i.MX) | 4 | 32 | 32 | 32 ✅ |
| aarch64 (Jetson) | 8 | 32 | 36+ | 32 ❌ |
| x86_64 | 8 | 64 | 68+ | 64 ❌ |

Symptom on Jetson:
```
$ ros2 topic echo /supervisor/light_state --once
data: 0.12090606987476349
$ tyndall_tool_ipc_read /dev/shm/...supervisor_light_state... ff
0(f): 0.000000      # phantom — 4 bytes of header padding read as float
1(f): 0.120906      # actual value, shifted by one float
```

## Fix

Compute `seq`, `size`, and `entry` offsets with `offsetof(seq_lock<char>, ...)` so the tool always agrees with the real struct layout the writer/reader templates use.

The templated `ipc_read()` API was never affected because the writer and reader both use `&this->entry` via the same struct definition.

## Follow-up

The underlying `seq_lock` `padding[]` calculation is also off on 64-bit (`entry` no longer starts on a cacheline boundary, defeating the false-sharing protection). Tracked separately in #16 so this PR stays minimal and unblocks the tool immediately.

## Testing

Not yet built — please cross-compile for jetson/imx to confirm. Native build wasn't available on my macOS host.