### PR TITLE
Fix seq_lock cacheline padding and CACHELINE_BYTES on aarch64 (#16)

### DIFF
--- a/tests/ipc/seq_lock_layout.cpp
+++ b/tests/ipc/seq_lock_layout.cpp
@@ -11,6 +11,7 @@
 // compile.
 
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <tyndall/ipc/seq_lock.h>

--- a/tests/ipc/seq_lock_layout.cpp
+++ b/tests/ipc/seq_lock_layout.cpp
@@ -1,0 +1,68 @@
+// Layout regression test for issue #16.
+//
+// seq_lock<STORAGE> must place `entry` on its own cacheline so the sequence
+// counter (seq/size) and the payload do not false-share. The offset of `entry`
+// must be exactly CACHELINE_BYTES on every ABI, independent of STORAGE's
+// alignment and of the padding the compiler inserts between `seq` (4B) and
+// `size` (8B on 64-bit targets).
+//
+// Before the fix, on 64-bit targets `entry` landed at 36/40 (aarch64) or 68/72
+// (x86_64) instead of CACHELINE_BYTES, so these static_asserts would fail to
+// compile.
+
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <tyndall/ipc/seq_lock.h>
+#include <tyndall/meta/macro.h>
+
+// Storage types spanning both alignment classes.
+using s_char = char;        // 1-byte aligned
+using s_float = float;      // 4-byte aligned
+struct s_vec3 {             // 8-byte aligned (the Vector3 repro)
+  double x, y, z;
+};
+struct s_mixed {            // mixed scalars, 8-byte aligned
+  long a;
+  double b;
+  char c;
+  unsigned long d;
+};
+
+template <typename STORAGE> constexpr void check_layout() {
+  static_assert(offsetof(seq_lock<STORAGE>, entry) == CACHELINE_BYTES,
+                "entry must start exactly one cacheline into seq_lock");
+  static_assert(offsetof(seq_lock<STORAGE>, entry) % CACHELINE_BYTES == 0,
+                "entry must be cacheline-aligned");
+}
+
+template void check_layout<s_char>();
+template void check_layout<s_float>();
+template void check_layout<s_vec3>();
+template void check_layout<s_mixed>();
+
+#define check(cond)                                                            \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      printf(__FILE__ ":" M_STRINGIFY(__LINE__) " Assertion failed: " #cond    \
+                                                "\n");                         \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+template <typename STORAGE> void check_runtime(const char *name) {
+  seq_lock<STORAGE> s{};
+  const size_t off =
+      reinterpret_cast<char *>(&s.entry) - reinterpret_cast<char *>(&s);
+  printf("seq_lock<%s>: offsetof(entry)=%zu CACHELINE_BYTES=%d sizeof=%zu\n",
+         name, off, (int)CACHELINE_BYTES, sizeof(seq_lock<STORAGE>));
+  check(off == CACHELINE_BYTES);
+}
+
+int main() {
+  check_runtime<s_char>("char");
+  check_runtime<s_float>("float");
+  check_runtime<s_vec3>("vec3");
+  check_runtime<s_mixed>("mixed");
+  return 0;
+}

--- a/tests/ipc/seq_lock_layout.cpp
+++ b/tests/ipc/seq_lock_layout.cpp
@@ -53,8 +53,10 @@ template void check_layout<s_mixed>();
 
 template <typename STORAGE> void check_runtime(const char *name) {
   seq_lock<STORAGE> s{};
-  const size_t off =
-      reinterpret_cast<char *>(&s.entry) - reinterpret_cast<char *>(&s);
+  // Use integer address arithmetic: subtracting char* derived from distinct
+  // subobjects is not well-defined.
+  const size_t off = reinterpret_cast<uintptr_t>(&s.entry) -
+                     reinterpret_cast<uintptr_t>(&s);
   printf("seq_lock<%s>: offsetof(entry)=%zu CACHELINE_BYTES=%d sizeof=%zu\n",
          name, off, (int)CACHELINE_BYTES, sizeof(seq_lock<STORAGE>));
   check(off == CACHELINE_BYTES);

--- a/tools/ipc_read.cpp
+++ b/tools/ipc_read.cpp
@@ -163,33 +163,12 @@ int main(int argc, char **argv) {
   // shared memory should be page aligned:
   assert(reinterpret_cast<uintptr_t>(mapped) % CACHELINE_BYTES == 0);
 
-  // The shared memory layout is defined by seq_lock<STORAGE>. The offsets of
-  // seq and size are fixed on a given platform (and computed with offsetof
-  // below), but the offset of entry depends on STORAGE's alignment: the
-  // compiler places entry right after padding[], rounded up to
-  // alignof(STORAGE). We don't know STORAGE here, but we can derive an upper
-  // bound on its alignment from the largest type in the format string.
+  // The shared memory layout is defined by seq_lock<STORAGE>. seq_lock aligns
+  // entry to CACHELINE_BYTES (see issue #16), so entry sits exactly one
+  // cacheline in regardless of STORAGE's alignment. That makes offsetof(entry)
+  // independent of STORAGE, so seq_lock<char> is a faithful probe for all three
+  // offsets.
   using probe_lock = seq_lock<char>;
-
-  auto format_char_align = [](char c) -> size_t {
-    switch (c) {
-    case 'd': // double
-    case 'l': // long
-    case 'm': // unsigned long
-    case 'x': // long long
-    case 'y': // unsigned long long
-      return 8;
-    case 'f': // float
-    case 'i': // int
-    case 'j': // unsigned int
-      return 4;
-    case 's': // short
-    case 't': // unsigned short
-      return 2;
-    default: // b(bool), c(char), h(unsigned char)
-      return 1;
-    }
-  };
 
   // Seq lock number address
   unsigned *ipc_seq =
@@ -199,9 +178,9 @@ int main(int argc, char **argv) {
   size_t *data_size =
       (size_t *)((char *)mapped + offsetof(probe_lock, size));
 
-  // Determine the format string up-front so we can compute the correct entry
-  // offset. If --format wasn't given, peek at the debug tailer at the end of
-  // the shmem region to recover it.
+  // Determine the format string used to decode/print the payload. If --format
+  // wasn't given, peek at the debug tailer at the end of the shmem region to
+  // recover it.
   std::string fmt_string;
   const std::vector<char> allowed = {'b', 'f', 'd', 'i', 'j', 's', 't',
                                      'c', 'h', 'l', 'm', 'x', 'y'};
@@ -225,15 +204,9 @@ int main(int argc, char **argv) {
     }
   }
 
-  // Round entry offset up to STORAGE's alignment (upper-bounded by the
-  // strictest format char). If we have no format hint, fall back to 1-byte
-  // alignment, which only matches byte-aligned STORAGE types.
-  size_t storage_align = 1;
-  for (char c : fmt_string)
-    storage_align = std::max(storage_align, format_char_align(c));
-
-  const size_t entry_offset =
-      (offsetof(probe_lock, entry) + storage_align - 1) & ~(storage_align - 1);
+  // entry is cacheline-aligned by seq_lock, so its offset is fixed regardless
+  // of STORAGE.
+  const size_t entry_offset = offsetof(probe_lock, entry);
 
   // Data address
   const char *const ipc_buf = (const char *)mapped + entry_offset;

--- a/tyndall/ipc/seq_lock.h
+++ b/tyndall/ipc/seq_lock.h
@@ -65,9 +65,14 @@ template <typename STORAGE> struct seq_lock {
   unsigned seq;
   size_t size;
 
-  char padding[CACHELINE_BYTES - sizeof(seq) - sizeof(size)];
-
-  STORAGE entry;
+  // Force entry onto its own cacheline so the sequence counter and payload do
+  // not false-share. alignas places entry at offsetof == CACHELINE_BYTES on
+  // every ABI, regardless of the alignment padding the compiler inserts between
+  // seq and size (4 bytes on 64-bit targets). See issue #16.
+  static_assert(alignof(STORAGE) <= CACHELINE_BYTES,
+                "STORAGE alignment exceeds cacheline; entry cannot be "
+                "cacheline-isolated");
+  alignas(CACHELINE_BYTES) STORAGE entry;
 
 public:
   using storage = STORAGE;

--- a/tyndall/ipc/smp.h
+++ b/tyndall/ipc/smp.h
@@ -12,9 +12,16 @@
 
 #define barrier() __asm__ __volatile__("" : : : "memory")
 
-#if __arm__ || __aarch64__ // tuned for armv7 (32-bit)
+#if __arm__ || __aarch64__
 
+#ifdef __aarch64__
+// Cortex-A (e.g. Orin/Cortex-A78AE) use 64-byte cache lines. Verified on target
+// via /sys/devices/system/cpu/cpu0/cache/index*/coherency_line_size.
+#define CACHELINE_BYTES 64
+#else
+// armv7 Cortex-A9 (i.MX): 32-byte cache lines.
 #define CACHELINE_BYTES 32
+#endif
 // L1:
 // https://developer.arm.com/documentation/ddi0388/f/Level-1-Memory-System/About-the-L1-memory-system
 // L2: https://community.nxp.com/thread/510105

--- a/tyndall/ipc/smp.h
+++ b/tyndall/ipc/smp.h
@@ -15,7 +15,7 @@
 #if __arm__ || __aarch64__
 
 #ifdef __aarch64__
-// Cortex-A (e.g. Orin/Cortex-A78AE) use 64-byte cache lines. Verified on target
+// Cortex-A (e.g. Orin/Cortex-A78AE) uses 64-byte cache lines. Verified on target
 // via /sys/devices/system/cpu/cpu0/cache/index*/coherency_line_size.
 #define CACHELINE_BYTES 64
 #else


### PR DESCRIPTION
Fixes #16.

## Summary

Two coupled shared-memory layout defects in `seq_lock`:

1. **Padding miscalculation.** `padding[CACHELINE_BYTES - sizeof(seq) - sizeof(size)]` assumed `seq` (4B) and `size` (8B) pack back-to-back. On 64-bit targets the compiler inserts 4 bytes between them, so the header is 16B not 12B and `entry` no longer started on a cacheline boundary (offset 36/40 on aarch64, 68/72 on x86_64) — defeating the seqlock's false-sharing isolation and causing the `ipc_read` tool to read garbage.

2. **Wrong `CACHELINE_BYTES` on aarch64.** `smp.h` hardcoded `32` for the whole `__arm__ || __aarch64__` branch. That's right for armv7 (i.MX/Cortex-A9) but every aarch64 core uses **64**-byte lines — verified on the target (Orin / Cortex-A78AE) via `/sys/devices/system/cpu/cpu0/cache/index*/coherency_line_size = 64`. Without this, even the corrected padding only isolated to a 32-byte boundary on Jetson, so `seq`/`size` and `entry` still shared a real cacheline.

## Changes

- **`tyndall/ipc/seq_lock.h`** — replace `padding[]` with `alignas(CACHELINE_BYTES) STORAGE entry;` (entry always at `offsetof == CACHELINE_BYTES`, independent of STORAGE alignment) + a `static_assert` guarding over-aligned STORAGE.
- **`tyndall/ipc/smp.h`** — split the ARM branch so aarch64 gets `CACHELINE_BYTES = 64`, armv7 keeps `32`.
- **`tools/ipc_read.cpp`** — drop the now-redundant `format_char_align`/`storage_align` rounding; compute `entry_offset = offsetof(seq_lock<char>, entry)` directly.
- **`tests/ipc/seq_lock_layout.cpp`** (new) — `static_assert` + runtime check that `offsetof(entry) == CACHELINE_BYTES` for storage types across alignment classes. Fails to compile on the buggy layout, so the bug can't regress.

## Verification

Multi-arch containers (QEMU), post-fix `entry` offset now equals the real cacheline on every ABI:

| ABI | before | after | `CACHELINE_BYTES` |
|---|---|---|---|
| armv7 (i.MX) | 32 ✅ | 32 | 32 |
| aarch64 (Orin) | 36/40 ❌ | **64** ✅ | 64 |
| x86_64 | 68/72 ❌ | 64 ✅ | 64 |

- Layout test runs green on all three arches (incl. 8-byte-aligned `vec3`/`mixed` that previously broke).
- Cross-compiled for **i.MX** and **Jetson** via the Yocto SDK: `tests` (incl. the new layout test — `static_asserts` pass on the real aarch64 toolchain) and `tyndall_tool_ipc_read` build cleanly.

See issue #16 for the full investigation, the multi-arch reproduction, and the on-device cache-line confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)